### PR TITLE
[Tizen] Add Clang install in Windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,10 +150,6 @@ jobs:
           (Get-Content ".gclient") | ForEach-Object {  $_ -replace "'flutter'","'.'"  } | Set-Content ".gclient"
           # TODO(jsuya) : pipes deprecated in python 3.13. (https://dart-review.googlesource.com/c/sdk/+/307620)
           (Get-Content "engine/src/build/vs_toolchain.py") | ForEach-Object {  $_ -replace 'import pipes',''  } | Set-Content "engine/src/build/vs_toolchain.py"
-
-          # TODO(jsuya) : Temporary fix to Microsoft STL compiler compatibility checks(https://github.com/flutter-tizen/flutter-tizen/pull/635#issuecomment-2990206946)
-          (Get-Content "engine/src/build/config/compiler/BUILD.gn") | ForEach-Object { $_; if ($_.Trim() -eq '"__STD_C",') { '    "_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH",' } } | Set-Content "engine/src/build/config/compiler/BUILD.gn"
-
           gclient setdep --var=download_dart_sdk=False --var=download_android_deps=False --var=download_fuchsia_deps=False --deps-file=DEPS
           gclient sync -v --no-history --shallow
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,12 @@ jobs:
           7z x -y -o"C:\workspace\depot_tools" .\depot_tools.zip
           echo "C:\workspace\depot_tools" >> $Env:GITHUB_PATH
 
+      - name: Set up Clang
+        uses: egor-tensin/setup-clang@v1
+        with:
+          version: 19.1.7
+          platform: x64
+
       - name: Run gclient sync
         working-directory: C:\workspace\flutter
         shell: powershell


### PR DESCRIPTION
Revert https://github.com/flutter-tizen/flutter/pull/9 PR and add a step to install Clang,

Refer to https://github.com/actions/runner-images/issues/12435