### PR TITLE
[Tizen] Fix external texture gl crash issue

### DIFF
--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -70,8 +70,10 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTexture(
     const SkISize& size) {
   if (!!aiks_context) {
     return ResolveTextureImpeller(texture_id, aiks_context, size);
-  } else {
+  } else if (!!context) {
     return ResolveTextureSkia(texture_id, context, size);
+  } else {
+    return nullptr;
   }
 }
 


### PR DESCRIPTION
Fix [[webview_flutter_tizen] Webview crashes when impeller is enabled](https://github.com/flutter-tizen/plugins/issues/933) issue.
