### PR TITLE
[Tizen] Re-implemented render external texture gl for impeller to avoid change FlutterOpenGLTexture and use deprecated api

### DIFF
--- a/engine/src/flutter/shell/platform/embedder/embedder.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder.h
@@ -405,7 +405,6 @@ typedef struct {
 } FlutterTransformation;
 
 typedef void (*VoidCallback)(void* /* user data */);
-typedef bool (*BoolCallback)(void* /* user data */);
 
 typedef enum {
   /// Specifies an OpenGL texture target type. Textures are specified using
@@ -513,13 +512,6 @@ typedef struct {
   uint32_t name;
   /// The texture format (example GL_RGBA8).
   uint32_t format;
-  /// The pixel data buffer.
-  const uint8_t* buffer;
-  /// The size of pixel buffer.
-  size_t buffer_size;
-  /// Callback invoked that the gpu surface texture start binding.
-  BoolCallback bind_callback;
-
   /// User data to be returned on the invocation of the destruction callback.
   void* user_data;
   /// Callback invoked (on an engine managed thread) that asks the embedder to
@@ -613,6 +605,7 @@ typedef struct {
   uint32_t format;
 } FlutterOpenGLSurface;
 
+typedef bool (*BoolCallback)(void* /* user data */);
 typedef FlutterTransformation (*TransformationCallback)(void* /* user data */);
 typedef uint32_t (*UIntCallback)(void* /* user data */);
 typedef bool (*SoftwareSurfacePresentCallback)(void* /* user data */,

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -226,6 +226,9 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
   if (size.width() <= 0 || size.height() <= 0) {
     FML_LOG(ERROR) << "Invalid texture size: " << size.width() << "x"
                    << size.height();
+    if (texture->destruction_callback) {
+      texture->destruction_callback(texture->user_data);
+    }
     return nullptr;
   }
 

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -136,6 +136,10 @@ bool EmbedderExternalTextureGL::IsExternalTextureChanged(
     return true;
   }
 
+  if (!texture_image_) {
+    return true;
+  }
+
   auto handle = texture_image_->GetGLHandle();
   if (!handle.has_value()) {
     return true;

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -130,11 +130,13 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureSkia(
 }
 
 bool EmbedderExternalTextureGL::IsExternalTextureChanged(
-    FlutterOpenGLTexture* texture) {
-  if (static_cast<int64_t>(texture->width) != desc_.size.width ||
-      static_cast<int64_t>(texture->height) != desc_.size.height) {
+    FlutterOpenGLTexture* texture,
+    impeller::TextureDescriptor& desc) {
+  if (static_cast<int64_t>(texture->width) != desc.size.width ||
+      static_cast<int64_t>(texture->height) != desc.size.height) {
     return true;
   }
+
   auto handle = texture_image_->GetGLHandle();
   if (!handle.has_value()) {
     return true;
@@ -143,6 +145,7 @@ bool EmbedderExternalTextureGL::IsExternalTextureChanged(
   if (handle.value() != texture->name) {
     return true;
   }
+
   return false;
 }
 
@@ -150,25 +153,14 @@ std::shared_ptr<impeller::TextureGLES>
 EmbedderExternalTextureGL::CreateImpellerTexture(
     impeller::AiksContext* aiks_context,
     FlutterOpenGLTexture* texture) {
-  // Validate input parameters
-  if (texture->width <= 0 || texture->height <= 0) {
-    FML_LOG(ERROR) << "Invalid texture dimensions: " << texture->width << "x"
-                   << texture->height;
-    return nullptr;
-  }
-
-  if (texture->name == 0) {
-    FML_LOG(ERROR) << "Invalid texture name (0)";
-    return nullptr;
-  }
-
-  desc_.size = impeller::ISize(texture->width, texture->height);
-  desc_.storage_mode = impeller::StorageMode::kDevicePrivate;
-  desc_.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
+  impeller::TextureDescriptor desc;
+  desc.size = impeller::ISize(texture->width, texture->height);
+  desc.storage_mode = impeller::StorageMode::kDevicePrivate;
+  desc.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
   if (texture->target == GL_TEXTURE_EXTERNAL_OES) {
-    desc_.type = impeller::TextureType::kTextureExternalOES;
+    desc.type = impeller::TextureType::kTextureExternalOES;
   } else {
-    desc_.type = impeller::TextureType::kTexture2D;
+    desc.type = impeller::TextureType::kTexture2D;
   }
 
   impeller::ContextGLES& context =
@@ -177,11 +169,9 @@ EmbedderExternalTextureGL::CreateImpellerTexture(
       impeller::HandleType::kTexture, texture->name);
 
   std::shared_ptr<impeller::TextureGLES> texture_image =
-      impeller::TextureGLES::WrapTexture(context.GetReactor(), desc_, handle);
+      impeller::TextureGLES::WrapTexture(context.GetReactor(), desc, handle);
 
   if (!texture_image) {
-    // In case Skia rejects the image, call the release proc so that
-    // embedders can perform collection of intermediates.
     if (texture->destruction_callback) {
       texture->destruction_callback(texture->user_data);
     }
@@ -194,19 +184,43 @@ EmbedderExternalTextureGL::CreateImpellerTexture(
   texture_image->SetCoordinateSystem(
       impeller::TextureCoordinateSystem::kUploadFromHost);
 
-  if (texture->destruction_callback &&
-      !context.GetReactor()->RegisterCleanupCallback(
-          handle,
-          [callback = texture->destruction_callback,
-           user_data = texture->user_data]() { callback(user_data); })) {
-    FML_LOG(ERROR) << "Could not register destruction callback for texture: "
-                   << texture->name;
-    // Clean up the texture since we couldn't register the callback
-    texture_image.reset();
-    return nullptr;
+  if (texture->destruction_callback) {
+    if (!context.GetReactor()->RegisterCleanupCallback(
+            handle,
+            [callback = texture->destruction_callback,
+             user_data = texture->user_data]() { callback(user_data); })) {
+      FML_LOG(ERROR) << "Could not register destruction callback for texture: "
+                     << texture->name;
+      texture_image.reset();
+      return nullptr;
+    }
   }
 
+  desc_ = desc;
   return texture_image;
+}
+
+bool EmbedderExternalTextureGL::ValidateTextureParameters(
+    FlutterOpenGLTexture* texture,
+    const SkISize& size) {
+  if (size.width() <= 0 || size.height() <= 0) {
+    FML_LOG(ERROR) << "Invalid texture size: " << size.width() << "x"
+                   << size.height();
+    if (texture->destruction_callback) {
+      texture->destruction_callback(texture->user_data);
+    }
+    return false;
+  }
+
+  if (texture->name == 0) {
+    FML_LOG(ERROR) << "Invalid texture name (0)";
+    if (texture->destruction_callback) {
+      texture->destruction_callback(texture->user_data);
+    }
+    return false;
+  }
+
+  return true;
 }
 
 sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
@@ -222,20 +236,14 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
     return nullptr;
   }
 
-  // Validate texture parameters
-  if (size.width() <= 0 || size.height() <= 0) {
-    FML_LOG(ERROR) << "Invalid texture size: " << size.width() << "x"
-                   << size.height();
-    if (texture->destruction_callback) {
-      texture->destruction_callback(texture->user_data);
-    }
+  if (!ValidateTextureParameters(texture.get(), size)) {
     return nullptr;
   }
 
-  if (texture_image_ == nullptr) {
+  if (!texture_image_) {
     texture_image_ = CreateImpellerTexture(aiks_context, texture.get());
   } else {
-    if (IsExternalTextureChanged(texture.get())) {
+    if (IsExternalTextureChanged(texture.get(), desc_)) {
       texture_image_.reset();
       texture_image_ = CreateImpellerTexture(aiks_context, texture.get());
     }

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -150,6 +150,18 @@ std::shared_ptr<impeller::TextureGLES>
 EmbedderExternalTextureGL::CreateImpellerTexture(
     impeller::AiksContext* aiks_context,
     FlutterOpenGLTexture* texture) {
+  // Validate input parameters
+  if (texture->width <= 0 || texture->height <= 0) {
+    FML_LOG(ERROR) << "Invalid texture dimensions: " << texture->width << "x"
+                   << texture->height;
+    return nullptr;
+  }
+
+  if (texture->name == 0) {
+    FML_LOG(ERROR) << "Invalid texture name (0)";
+    return nullptr;
+  }
+
   desc_.size = impeller::ISize(texture->width, texture->height);
   desc_.storage_mode = impeller::StorageMode::kDevicePrivate;
   desc_.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
@@ -173,7 +185,9 @@ EmbedderExternalTextureGL::CreateImpellerTexture(
     if (texture->destruction_callback) {
       texture->destruction_callback(texture->user_data);
     }
-    FML_LOG(ERROR) << "Could not create external texture";
+    FML_LOG(ERROR) << "Could not create external texture with name: "
+                   << texture->name << ", size: " << texture->width << "x"
+                   << texture->height;
     return nullptr;
   }
 
@@ -185,7 +199,10 @@ EmbedderExternalTextureGL::CreateImpellerTexture(
           handle,
           [callback = texture->destruction_callback,
            user_data = texture->user_data]() { callback(user_data); })) {
-    FML_LOG(ERROR) << "Could not register destruction callback";
+    FML_LOG(ERROR) << "Could not register destruction callback for texture: "
+                   << texture->name;
+    // Clean up the texture since we couldn't register the callback
+    texture_image.reset();
     return nullptr;
   }
 
@@ -200,6 +217,15 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
       external_texture_callback_(texture_id, size.width(), size.height());
 
   if (!texture) {
+    FML_LOG(ERROR) << "External texture callback returned null for texture_id: "
+                   << texture_id;
+    return nullptr;
+  }
+
+  // Validate texture parameters
+  if (size.width() <= 0 || size.height() <= 0) {
+    FML_LOG(ERROR) << "Invalid texture size: " << size.width() << "x"
+                   << size.height();
     return nullptr;
   }
 
@@ -213,6 +239,8 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
   }
 
   if (texture_image_ == nullptr) {
+    FML_LOG(ERROR) << "Failed to create Impeller texture for texture_id: "
+                   << texture_id;
     return nullptr;
   }
 

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -140,33 +140,22 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
     return nullptr;
   }
 
-  if (texture->bind_callback != nullptr) {
-    return ResolveTextureImpellerSurface(aiks_context, std::move(texture));
-  } else {
-    return ResolveTextureImpellerPixelbuffer(aiks_context, std::move(texture));
-  }
-}
-
-sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpellerPixelbuffer(
-    impeller::AiksContext* aiks_context,
-    std::unique_ptr<FlutterOpenGLTexture> texture) {
   impeller::TextureDescriptor desc;
   desc.size = impeller::ISize(texture->width, texture->height);
-  desc.type = impeller::TextureType::kTexture2D;
   desc.storage_mode = impeller::StorageMode::kDevicePrivate;
   desc.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
+  if (texture->target == GL_TEXTURE_EXTERNAL_OES) {
+    desc.type = impeller::TextureType::kTextureExternalOES;
+  } else {
+    desc.type = impeller::TextureType::kTexture2D;
+  }
+
   impeller::ContextGLES& context =
       impeller::ContextGLES::Cast(*aiks_context->GetContext());
+  impeller::HandleGLES handle = context.GetReactor()->CreateHandle(
+      impeller::HandleType::kTexture, texture->name);
   std::shared_ptr<impeller::TextureGLES> image =
-      std::make_shared<impeller::TextureGLES>(context.GetReactor(), desc);
-
-  image->MarkContentsInitialized();
-  if (!image->SetContents(texture->buffer, texture->buffer_size)) {
-    if (texture->destruction_callback) {
-      texture->destruction_callback(texture->user_data);
-    }
-    return nullptr;
-  }
+      impeller::TextureGLES::WrapTexture(context.GetReactor(), desc, handle);
 
   if (!image) {
     // In case Skia rejects the image, call the release proc so that
@@ -177,56 +166,15 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpellerPixelbuffer(
     FML_LOG(ERROR) << "Could not create external texture";
     return nullptr;
   }
-
-  if (texture->destruction_callback) {
-    texture->destruction_callback(texture->user_data);
-  }
-
-  return impeller::DlImageImpeller::Make(image);
-}
-
-sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpellerSurface(
-    impeller::AiksContext* aiks_context,
-    std::unique_ptr<FlutterOpenGLTexture> texture) {
-  impeller::TextureDescriptor desc;
-  desc.size = impeller::ISize(texture->width, texture->height);
-  desc.storage_mode = impeller::StorageMode::kDevicePrivate;
-  desc.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
-  desc.type = impeller::TextureType::kTextureExternalOES;
-  impeller::ContextGLES& context =
-      impeller::ContextGLES::Cast(*aiks_context->GetContext());
-  std::shared_ptr<impeller::TextureGLES> image =
-      std::make_shared<impeller::TextureGLES>(context.GetReactor(), desc);
-  image->MarkContentsInitialized();
   image->SetCoordinateSystem(
       impeller::TextureCoordinateSystem::kUploadFromHost);
-  if (!image->Bind()) {
-    if (texture->destruction_callback) {
-      texture->destruction_callback(texture->user_data);
-    }
-    FML_LOG(ERROR) << "Could not bind texture";
+  if (texture->destruction_callback &&
+      !context.GetReactor()->RegisterCleanupCallback(
+          handle,
+          [callback = texture->destruction_callback,
+           user_data = texture->user_data]() { callback(user_data); })) {
+    FML_LOG(ERROR) << "Could not register destruction callback";
     return nullptr;
-  }
-
-  if (!image) {
-    // In case Skia rejects the image, call the release proc so that
-    // embedders can perform collection of intermediates.
-    if (texture->destruction_callback) {
-      texture->destruction_callback(texture->user_data);
-    }
-    FML_LOG(ERROR) << "Could not create external texture";
-    return nullptr;
-  }
-
-  if (!texture->bind_callback(texture->user_data)) {
-    if (texture->destruction_callback) {
-      texture->destruction_callback(texture->user_data);
-    }
-    return nullptr;
-  }
-
-  if (texture->destruction_callback) {
-    texture->destruction_callback(texture->user_data);
   }
 
   return impeller::DlImageImpeller::Make(image);

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -129,6 +129,69 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureSkia(
   return DlImage::Make(std::move(image));
 }
 
+bool EmbedderExternalTextureGL::IsExternalTextureChanged(
+    FlutterOpenGLTexture* texture) {
+  if (static_cast<int64_t>(texture->width) != desc_.size.width ||
+      static_cast<int64_t>(texture->height) != desc_.size.height) {
+    return true;
+  }
+  auto handle = texture_image_->GetGLHandle();
+  if (!handle.has_value()) {
+    return true;
+  }
+
+  if (handle.value() != texture->name) {
+    return true;
+  }
+  return false;
+}
+
+std::shared_ptr<impeller::TextureGLES>
+EmbedderExternalTextureGL::CreateImpellerTexture(
+    impeller::AiksContext* aiks_context,
+    FlutterOpenGLTexture* texture) {
+  desc_.size = impeller::ISize(texture->width, texture->height);
+  desc_.storage_mode = impeller::StorageMode::kDevicePrivate;
+  desc_.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
+  if (texture->target == GL_TEXTURE_EXTERNAL_OES) {
+    desc_.type = impeller::TextureType::kTextureExternalOES;
+  } else {
+    desc_.type = impeller::TextureType::kTexture2D;
+  }
+
+  impeller::ContextGLES& context =
+      impeller::ContextGLES::Cast(*aiks_context->GetContext());
+  impeller::HandleGLES handle = context.GetReactor()->CreateHandle(
+      impeller::HandleType::kTexture, texture->name);
+
+  std::shared_ptr<impeller::TextureGLES> texture_image =
+      impeller::TextureGLES::WrapTexture(context.GetReactor(), desc_, handle);
+
+  if (!texture_image) {
+    // In case Skia rejects the image, call the release proc so that
+    // embedders can perform collection of intermediates.
+    if (texture->destruction_callback) {
+      texture->destruction_callback(texture->user_data);
+    }
+    FML_LOG(ERROR) << "Could not create external texture";
+    return nullptr;
+  }
+
+  texture_image->SetCoordinateSystem(
+      impeller::TextureCoordinateSystem::kUploadFromHost);
+
+  if (texture->destruction_callback &&
+      !context.GetReactor()->RegisterCleanupCallback(
+          handle,
+          [callback = texture->destruction_callback,
+           user_data = texture->user_data]() { callback(user_data); })) {
+    FML_LOG(ERROR) << "Could not register destruction callback";
+    return nullptr;
+  }
+
+  return texture_image;
+}
+
 sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
     int64_t texture_id,
     impeller::AiksContext* aiks_context,
@@ -140,44 +203,20 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
     return nullptr;
   }
 
-  impeller::TextureDescriptor desc;
-  desc.size = impeller::ISize(texture->width, texture->height);
-  desc.storage_mode = impeller::StorageMode::kDevicePrivate;
-  desc.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
-  if (texture->target == GL_TEXTURE_EXTERNAL_OES) {
-    desc.type = impeller::TextureType::kTextureExternalOES;
+  if (texture_image_ == nullptr) {
+    texture_image_ = CreateImpellerTexture(aiks_context, texture.get());
   } else {
-    desc.type = impeller::TextureType::kTexture2D;
-  }
-
-  impeller::ContextGLES& context =
-      impeller::ContextGLES::Cast(*aiks_context->GetContext());
-  impeller::HandleGLES handle = context.GetReactor()->CreateHandle(
-      impeller::HandleType::kTexture, texture->name);
-  std::shared_ptr<impeller::TextureGLES> image =
-      impeller::TextureGLES::WrapTexture(context.GetReactor(), desc, handle);
-
-  if (!image) {
-    // In case Skia rejects the image, call the release proc so that
-    // embedders can perform collection of intermediates.
-    if (texture->destruction_callback) {
-      texture->destruction_callback(texture->user_data);
+    if (IsExternalTextureChanged(texture.get())) {
+      texture_image_.reset();
+      texture_image_ = CreateImpellerTexture(aiks_context, texture.get());
     }
-    FML_LOG(ERROR) << "Could not create external texture";
-    return nullptr;
   }
-  image->SetCoordinateSystem(
-      impeller::TextureCoordinateSystem::kUploadFromHost);
-  if (texture->destruction_callback &&
-      !context.GetReactor()->RegisterCleanupCallback(
-          handle,
-          [callback = texture->destruction_callback,
-           user_data = texture->user_data]() { callback(user_data); })) {
-    FML_LOG(ERROR) << "Could not register destruction callback";
+
+  if (texture_image_ == nullptr) {
     return nullptr;
   }
 
-  return impeller::DlImageImpeller::Make(image);
+  return impeller::DlImageImpeller::Make(texture_image_);
 }
 
 // |flutter::Texture|

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -130,10 +130,9 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureSkia(
 }
 
 bool EmbedderExternalTextureGL::IsExternalTextureChanged(
-    FlutterOpenGLTexture* texture,
-    impeller::TextureDescriptor& desc) {
-  if (static_cast<int64_t>(texture->width) != desc.size.width ||
-      static_cast<int64_t>(texture->height) != desc.size.height) {
+    FlutterOpenGLTexture* texture) {
+  if (static_cast<int64_t>(texture->width) != desc_.size.width ||
+      static_cast<int64_t>(texture->height) != desc_.size.height) {
     return true;
   }
 
@@ -243,7 +242,7 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
   if (!texture_image_) {
     texture_image_ = CreateImpellerTexture(aiks_context, texture.get());
   } else {
-    if (IsExternalTextureChanged(texture.get(), desc_)) {
+    if (IsExternalTextureChanged(texture.get())) {
       texture_image_.reset();
       texture_image_ = CreateImpellerTexture(aiks_context, texture.get());
     }

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
@@ -41,7 +41,12 @@ class EmbedderExternalTextureGL : public flutter::Texture {
                                         impeller::AiksContext* aiks_context,
                                         const SkISize& size);
 
-  bool IsExternalTextureChanged(FlutterOpenGLTexture* texture);
+  bool ValidateTextureParameters(FlutterOpenGLTexture* texture,
+                                 const SkISize& size);
+
+  bool IsExternalTextureChanged(FlutterOpenGLTexture* texture,
+                                impeller::TextureDescriptor& desc);
+
   std::shared_ptr<impeller::TextureGLES> CreateImpellerTexture(
       impeller::AiksContext* aiks_context,
       FlutterOpenGLTexture* texture);

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
@@ -8,6 +8,7 @@
 #include "flutter/common/graphics/texture.h"
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/embedder/embedder.h"
+#include "impeller/renderer/backend/gles/texture_gles.h"
 #include "third_party/skia/include/core/SkSize.h"
 
 namespace flutter {
@@ -25,7 +26,8 @@ class EmbedderExternalTextureGL : public flutter::Texture {
  private:
   const ExternalTextureCallback& external_texture_callback_;
   sk_sp<DlImage> last_image_;
-
+  std::shared_ptr<impeller::TextureGLES> texture_image_ = nullptr;
+  impeller::TextureDescriptor desc_;
   sk_sp<DlImage> ResolveTexture(int64_t texture_id,
                                 GrDirectContext* context,
                                 impeller::AiksContext* aiks_context,
@@ -38,6 +40,11 @@ class EmbedderExternalTextureGL : public flutter::Texture {
   sk_sp<DlImage> ResolveTextureImpeller(int64_t texture_id,
                                         impeller::AiksContext* aiks_context,
                                         const SkISize& size);
+
+  bool IsExternalTextureChanged(FlutterOpenGLTexture* texture);
+  std::shared_ptr<impeller::TextureGLES> CreateImpellerTexture(
+      impeller::AiksContext* aiks_context,
+      FlutterOpenGLTexture* texture);
 
   // |flutter::Texture|
   void Paint(PaintContext& context,

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
@@ -44,8 +44,7 @@ class EmbedderExternalTextureGL : public flutter::Texture {
   bool ValidateTextureParameters(FlutterOpenGLTexture* texture,
                                  const SkISize& size);
 
-  bool IsExternalTextureChanged(FlutterOpenGLTexture* texture,
-                                impeller::TextureDescriptor& desc);
+  bool IsExternalTextureChanged(FlutterOpenGLTexture* texture);
 
   std::shared_ptr<impeller::TextureGLES> CreateImpellerTexture(
       impeller::AiksContext* aiks_context,

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
@@ -39,14 +39,6 @@ class EmbedderExternalTextureGL : public flutter::Texture {
                                         impeller::AiksContext* aiks_context,
                                         const SkISize& size);
 
-  sk_sp<DlImage> ResolveTextureImpellerPixelbuffer(
-      impeller::AiksContext* aiks_context,
-      std::unique_ptr<FlutterOpenGLTexture> texture);
-
-  sk_sp<DlImage> ResolveTextureImpellerSurface(
-      impeller::AiksContext* aiks_context,
-      std::unique_ptr<FlutterOpenGLTexture> texture);
-
   // |flutter::Texture|
   void Paint(PaintContext& context,
              const DlRect& bounds,


### PR DESCRIPTION
We have supported render external texture gl for Impeller
https://github.com/flutter-tizen/engine/pull/368
But this PR has two issues:
1. It modify FlutterOpenGLTexture, it added additional variables, not a good design.
```C++
  /// The pixel data buffer.
  const uint8_t* buffer;
  /// The size of pixel buffer.
  size_t buffer_size;
  /// Callback invoked that the gpu surface texture start binding.
  BoolCallback bind_callback;
  /// The type of the texture.
  FlutterGLImpellerTextureType impeller_texture_type;
```
2. It uses Deprecated API
```C++
  // Deprecated: use BlitPass::AddCopy instead.
  [[nodiscard]] bool SetContents(const uint8_t* contents,
                                 size_t length,
                                 size_t slice = 0,
                                 bool is_opaque = false);

```

So I tried to revert offical PR to render external gl for impeller
https://github.com/flutter/engine/pull/56277
But this PR doesn't work on Tizen platform, I think This PR may not have been verified.
To avoid change FlutterOpenGLTexture and use deprecated api, so I re-implemented render external texture gl for impeller based on this offical PR.
Fix https://github.com/flutter-tizen/embedder/issues/131


