### PR TITLE
[Tizen] Re-implemented render external texture gl for impeller to avoid change FlutterOpenGLTexture and use deprecated api

### DIFF
--- a/engine/src/flutter/shell/platform/embedder/embedder.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder.h
@@ -405,7 +405,6 @@ typedef struct {
 } FlutterTransformation;
 
 typedef void (*VoidCallback)(void* /* user data */);
-typedef bool (*BoolCallback)(void* /* user data */);
 
 typedef enum {
   /// Specifies an OpenGL texture target type. Textures are specified using
@@ -513,13 +512,6 @@ typedef struct {
   uint32_t name;
   /// The texture format (example GL_RGBA8).
   uint32_t format;
-  /// The pixel data buffer.
-  const uint8_t* buffer;
-  /// The size of pixel buffer.
-  size_t buffer_size;
-  /// Callback invoked that the gpu surface texture start binding.
-  BoolCallback bind_callback;
-
   /// User data to be returned on the invocation of the destruction callback.
   void* user_data;
   /// Callback invoked (on an engine managed thread) that asks the embedder to
@@ -613,6 +605,7 @@ typedef struct {
   uint32_t format;
 } FlutterOpenGLSurface;
 
+typedef bool (*BoolCallback)(void* /* user data */);
 typedef FlutterTransformation (*TransformationCallback)(void* /* user data */);
 typedef uint32_t (*UIntCallback)(void* /* user data */);
 typedef bool (*SoftwareSurfacePresentCallback)(void* /* user data */,

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -27,6 +27,97 @@
 
 namespace flutter {
 
+std::optional<TextureLRU::Data> TextureLRU::FindTexture(
+    std::optional<GLuint> key) {
+  if (!key.has_value()) {
+    return std::nullopt;
+  }
+  auto key_value = key.value();
+  for (size_t i = 0u; i < kTextureMaxSize; i++) {
+    if (textures_[i].key == key_value) {
+      auto result = textures_[i].value;
+      UpdateTexture(result, key_value, textures_[i].width, textures_[i].height);
+      return std::make_optional(textures_[i]);
+    }
+  }
+  return std::nullopt;
+}
+
+void TextureLRU::UpdateTexture(
+    const std::shared_ptr<impeller::TextureGLES>& texture,
+    GLuint key,
+    size_t width,
+    size_t height) {
+  if (textures_[0].key == key) {
+    textures_[0].value = texture;
+    textures_[0].width = width;
+    textures_[0].height = height;
+    return;
+  }
+  size_t i = 1u;
+  for (; i < kTextureMaxSize; i++) {
+    if (textures_[i].key == key) {
+      break;
+    }
+  }
+  for (auto j = i; j > 0; j--) {
+    textures_[j] = textures_[j - 1];
+  }
+  textures_[0] =
+      Data{.key = key, .value = texture, .width = width, .height = height};
+}
+
+GLuint TextureLRU::AddTexture(
+    const std::shared_ptr<impeller::TextureGLES>& texture,
+    GLuint key,
+    size_t width,
+    size_t height) {
+  GLuint lru_key = textures_[kTextureMaxSize - 1].key;
+  bool updated_image = false;
+  for (size_t i = 0u; i < kTextureMaxSize; i++) {
+    if (textures_[i].key == lru_key) {
+      updated_image = true;
+      textures_[i] =
+          Data{.key = key, .value = texture, .width = width, .height = height};
+      break;
+    }
+  }
+  if (!updated_image) {
+    textures_[0] =
+        Data{.key = key, .value = texture, .width = width, .height = height};
+  }
+  UpdateTexture(texture, key, width, height);
+  return lru_key;
+}
+
+void TextureLRU::Clear() {
+  for (size_t i = 0u; i < kTextureMaxSize; i++) {
+    textures_[i] = Data{.key = 0u, .value = nullptr};
+  }
+}
+
+void TextureLRU::RemoveTexture(GLuint key) {
+  size_t i = 0u;
+  for (; i < kTextureMaxSize; i++) {
+    if (textures_[i].key == key) {
+      break;
+    }
+  }
+
+  // If key not found, return
+  if (i == kTextureMaxSize) {
+    return;
+  }
+
+  // Shift all entries after the found entry down by one position
+  for (; i < kTextureMaxSize - 1; i++) {
+    textures_[i] = textures_[i + 1];
+  }
+
+  // Clear the last entry
+  textures_[kTextureMaxSize - 1] = Data{.key = 0u, .value = nullptr};
+}
+
 EmbedderExternalTextureGL::EmbedderExternalTextureGL(
     int64_t texture_identifier,
     const ExternalTextureCallback& callback)
@@ -129,6 +220,50 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureSkia(
   return DlImage::Make(std::move(image));
 }
 
+std::shared_ptr<impeller::TextureGLES>
+EmbedderExternalTextureGL::CreateTextureGLES(
+    impeller::AiksContext* aiks_context,
+    FlutterOpenGLTexture* texture) {
+  impeller::TextureDescriptor desc;
+  desc.size = impeller::ISize(texture->width, texture->height);
+  desc.storage_mode = impeller::StorageMode::kDevicePrivate;
+  desc.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
+  if (texture->target == GL_TEXTURE_EXTERNAL_OES) {
+    desc.type = impeller::TextureType::kTextureExternalOES;
+  } else {
+    desc.type = impeller::TextureType::kTexture2D;
+  }
+  impeller::ContextGLES& context =
+      impeller::ContextGLES::Cast(*aiks_context->GetContext());
+  impeller::HandleGLES handle = context.GetReactor()->CreateHandle(
+      impeller::HandleType::kTexture, texture->name);
+
+  auto gles_texture =
+      impeller::TextureGLES::WrapTexture(context.GetReactor(), desc, handle);
+  if (!gles_texture) {
+    // In case Skia rejects the image, call the release proc so that
+    // embedders can perform collection of intermediates.
+    if (texture->destruction_callback) {
+      texture->destruction_callback(texture->user_data);
+    }
+    FML_LOG(ERROR) << "Could not create external texture";
+    return nullptr;
+  }
+
+  gles_texture->SetCoordinateSystem(
+      impeller::TextureCoordinateSystem::kUploadFromHost);
+
+  if (texture->destruction_callback &&
+      !context.GetReactor()->RegisterCleanupCallback(
+          handle,
+          [callback = texture->destruction_callback,
+           user_data = texture->user_data]() { callback(user_data); })) {
+    FML_LOG(ERROR) << "Could not register destruction callback";
+    return nullptr;
+  }
+  return gles_texture;
+}
+
 sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
     int64_t texture_id,
     impeller::AiksContext* aiks_context,
@@ -140,53 +275,44 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
     return nullptr;
   }
 
-  std::shared_ptr<impeller::TextureGLES> image;
+  std::optional<TextureLRU::Data> texture_data =
+      texture_lru_.FindTexture(texture->name);
 
-  auto it = impeller_gl_textures_.find(texture->name);
-  if (it != impeller_gl_textures_.end()) {
-    image = it->second;
-  } else {
-    impeller::TextureDescriptor desc;
-    desc.size = impeller::ISize(texture->width, texture->height);
-    desc.storage_mode = impeller::StorageMode::kDevicePrivate;
-    desc.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
-    if (texture->target == GL_TEXTURE_EXTERNAL_OES) {
-      desc.type = impeller::TextureType::kTextureExternalOES;
-    } else {
-      desc.type = impeller::TextureType::kTexture2D;
-    }
-    impeller::ContextGLES& context =
-        impeller::ContextGLES::Cast(*aiks_context->GetContext());
-    impeller::HandleGLES handle = context.GetReactor()->CreateHandle(
-        impeller::HandleType::kTexture, texture->name);
+  bool size_change = false;
 
-    image =
-        impeller::TextureGLES::WrapTexture(context.GetReactor(), desc, handle);
-    if (!image) {
-      // In case Skia rejects the image, call the release proc so that
-      // embedders can perform collection of intermediates.
-      if (texture->destruction_callback) {
-        texture->destruction_callback(texture->user_data);
-      }
-      FML_LOG(ERROR) << "Could not create external texture";
-      return nullptr;
-    }
-
-    image->SetCoordinateSystem(
-        impeller::TextureCoordinateSystem::kUploadFromHost);
-
-    if (texture->destruction_callback &&
-        !context.GetReactor()->RegisterCleanupCallback(
-            handle,
-            [callback = texture->destruction_callback,
-             user_data = texture->user_data]() { callback(user_data); })) {
-      FML_LOG(ERROR) << "Could not register destruction callback";
-      return nullptr;
-    }
-    impeller_gl_textures_[texture->name] = image;
+  if (texture_data.has_value() &&
+      (texture_data.value().width != texture->width ||
+       texture_data.value().height != texture->height)) {
+    size_change = true;
   }
 
-  return impeller::DlImageImpeller::Make(image);
+  if (texture_data.has_value() && !size_change) {
+    return impeller::DlImageImpeller::Make(texture_data.value().value);
+  } else if (texture_data.has_value() && size_change) {
+    std::shared_ptr<impeller::TextureGLES> old_gles_texture =
+        texture_data.value().value;
+    old_gles_texture->Leak();
+    std::shared_ptr<impeller::TextureGLES> new_gles_texture =
+        CreateTextureGLES(aiks_context, texture.get());
+    if (new_gles_texture) {
+      texture_lru_.UpdateTexture(new_gles_texture, texture->name, texture->width,
+                                 texture->height);
+      return impeller::DlImageImpeller::Make(new_gles_texture);
+    } else {
+      texture_lru_.RemoveTexture(texture->name);
+      return nullptr;
+    }
+  } else {
+    std::shared_ptr<impeller::TextureGLES> new_gles_texture =
+        CreateTextureGLES(aiks_context, texture.get());
+    if (new_gles_texture) {
+      texture_lru_.AddTexture(new_gles_texture, texture->name, texture->width,
+                              texture->height);
+      return impeller::DlImageImpeller::Make(new_gles_texture);
+    } else {
+      return nullptr;
+    }
+  }
 }
 
 // |flutter::Texture|
@@ -201,6 +327,8 @@ void EmbedderExternalTextureGL::MarkNewFrameAvailable() {
 }
 
 // |flutter::Texture|
-void EmbedderExternalTextureGL::OnTextureUnregistered() {}
+void EmbedderExternalTextureGL::OnTextureUnregistered() {
+  texture_lru_.Clear();
+}
 
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -36,57 +36,47 @@ std::optional<TextureLRU::Data> TextureLRU::FindTexture(
   for (size_t i = 0u; i < kTextureMaxSize; i++) {
     if (textures_[i].key == key_value) {
       auto result = textures_[i].value;
-      UpdateTexture(result, key_value, textures_[i].width, textures_[i].height);
+      UpdateTexture(Data{.key = key_value,
+                         .value = result,
+                         .width = textures_[i].width,
+                         .height = textures_[i].height});
       return std::make_optional(textures_[i]);
     }
   }
   return std::nullopt;
 }
 
-void TextureLRU::UpdateTexture(
-    const std::shared_ptr<impeller::TextureGLES>& texture,
-    GLuint key,
-    size_t width,
-    size_t height) {
-  if (textures_[0].key == key) {
-    textures_[0].value = texture;
-    textures_[0].width = width;
-    textures_[0].height = height;
+void TextureLRU::UpdateTexture(Data data) {
+  if (textures_[0].key == data.key) {
+    textures_[0] = data;
     return;
   }
   size_t i = 1u;
   for (; i < kTextureMaxSize; i++) {
-    if (textures_[i].key == key) {
+    if (textures_[i].key == data.key) {
       break;
     }
   }
   for (auto j = i; j > 0; j--) {
     textures_[j] = textures_[j - 1];
   }
-  textures_[0] =
-      Data{.key = key, .value = texture, .width = width, .height = height};
+  textures_[0] = data;
 }
 
-GLuint TextureLRU::AddTexture(
-    const std::shared_ptr<impeller::TextureGLES>& texture,
-    GLuint key,
-    size_t width,
-    size_t height) {
+GLuint TextureLRU::AddTexture(Data data) {
   GLuint lru_key = textures_[kTextureMaxSize - 1].key;
   bool updated_image = false;
   for (size_t i = 0u; i < kTextureMaxSize; i++) {
     if (textures_[i].key == lru_key) {
       updated_image = true;
-      textures_[i] =
-          Data{.key = key, .value = texture, .width = width, .height = height};
+      textures_[i] = data;
       break;
     }
   }
   if (!updated_image) {
-    textures_[0] =
-        Data{.key = key, .value = texture, .width = width, .height = height};
+    textures_[0] = data;
   }
-  UpdateTexture(texture, key, width, height);
+  UpdateTexture(data);
   return lru_key;
 }
 
@@ -104,17 +94,14 @@ void TextureLRU::RemoveTexture(GLuint key) {
     }
   }
 
-  // If key not found, return
   if (i == kTextureMaxSize) {
     return;
   }
 
-  // Shift all entries after the found entry down by one position
   for (; i < kTextureMaxSize - 1; i++) {
     textures_[i] = textures_[i + 1];
   }
 
-  // Clear the last entry
   textures_[kTextureMaxSize - 1] = Data{.key = 0u, .value = nullptr};
 }
 
@@ -295,8 +282,11 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
     std::shared_ptr<impeller::TextureGLES> new_gles_texture =
         CreateTextureGLES(aiks_context, texture.get());
     if (new_gles_texture) {
-      texture_lru_.UpdateTexture(new_gles_texture, texture->name, texture->width,
-                                 texture->height);
+      texture_lru_.UpdateTexture(TextureLRU::Data{.key = texture->name,
+                                                  .value = new_gles_texture,
+                                                  .width = texture->width,
+                                                  .height = texture->height});
+
       return impeller::DlImageImpeller::Make(new_gles_texture);
     } else {
       texture_lru_.RemoveTexture(texture->name);
@@ -306,8 +296,10 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
     std::shared_ptr<impeller::TextureGLES> new_gles_texture =
         CreateTextureGLES(aiks_context, texture.get());
     if (new_gles_texture) {
-      texture_lru_.AddTexture(new_gles_texture, texture->name, texture->width,
-                              texture->height);
+      texture_lru_.AddTexture(TextureLRU::Data{.key = texture->name,
+                                               .value = new_gles_texture,
+                                               .width = texture->width,
+                                               .height = texture->height});
       return impeller::DlImageImpeller::Make(new_gles_texture);
     } else {
       return nullptr;

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -140,93 +140,50 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
     return nullptr;
   }
 
-  if (texture->bind_callback != nullptr) {
-    return ResolveTextureImpellerSurface(aiks_context, std::move(texture));
+  std::shared_ptr<impeller::TextureGLES> image;
+
+  auto it = impeller_gl_textures_.find(texture->name);
+  if (it != impeller_gl_textures_.end()) {
+    image = it->second;
   } else {
-    return ResolveTextureImpellerPixelbuffer(aiks_context, std::move(texture));
-  }
-}
-
-sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpellerPixelbuffer(
-    impeller::AiksContext* aiks_context,
-    std::unique_ptr<FlutterOpenGLTexture> texture) {
-  impeller::TextureDescriptor desc;
-  desc.size = impeller::ISize(texture->width, texture->height);
-  desc.type = impeller::TextureType::kTexture2D;
-  desc.storage_mode = impeller::StorageMode::kDevicePrivate;
-  desc.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
-  impeller::ContextGLES& context =
-      impeller::ContextGLES::Cast(*aiks_context->GetContext());
-  std::shared_ptr<impeller::TextureGLES> image =
-      std::make_shared<impeller::TextureGLES>(context.GetReactor(), desc);
-
-  image->MarkContentsInitialized();
-  if (!image->SetContents(texture->buffer, texture->buffer_size)) {
-    if (texture->destruction_callback) {
-      texture->destruction_callback(texture->user_data);
+    impeller::TextureDescriptor desc;
+    desc.size = impeller::ISize(texture->width, texture->height);
+    desc.storage_mode = impeller::StorageMode::kDevicePrivate;
+    desc.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
+    if (texture->target == GL_TEXTURE_EXTERNAL_OES) {
+      desc.type = impeller::TextureType::kTextureExternalOES;
+    } else {
+      desc.type = impeller::TextureType::kTexture2D;
     }
-    return nullptr;
-  }
+    impeller::ContextGLES& context =
+        impeller::ContextGLES::Cast(*aiks_context->GetContext());
+    impeller::HandleGLES handle = context.GetReactor()->CreateHandle(
+        impeller::HandleType::kTexture, texture->name);
 
-  if (!image) {
-    // In case Skia rejects the image, call the release proc so that
-    // embedders can perform collection of intermediates.
-    if (texture->destruction_callback) {
-      texture->destruction_callback(texture->user_data);
+    image =
+        impeller::TextureGLES::WrapTexture(context.GetReactor(), desc, handle);
+    if (!image) {
+      // In case Skia rejects the image, call the release proc so that
+      // embedders can perform collection of intermediates.
+      if (texture->destruction_callback) {
+        texture->destruction_callback(texture->user_data);
+      }
+      FML_LOG(ERROR) << "Could not create external texture";
+      return nullptr;
     }
-    FML_LOG(ERROR) << "Could not create external texture";
-    return nullptr;
-  }
 
-  if (texture->destruction_callback) {
-    texture->destruction_callback(texture->user_data);
-  }
+    image->SetCoordinateSystem(
+        impeller::TextureCoordinateSystem::kUploadFromHost);
 
-  return impeller::DlImageImpeller::Make(image);
-}
-
-sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpellerSurface(
-    impeller::AiksContext* aiks_context,
-    std::unique_ptr<FlutterOpenGLTexture> texture) {
-  impeller::TextureDescriptor desc;
-  desc.size = impeller::ISize(texture->width, texture->height);
-  desc.storage_mode = impeller::StorageMode::kDevicePrivate;
-  desc.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
-  desc.type = impeller::TextureType::kTextureExternalOES;
-  impeller::ContextGLES& context =
-      impeller::ContextGLES::Cast(*aiks_context->GetContext());
-  std::shared_ptr<impeller::TextureGLES> image =
-      std::make_shared<impeller::TextureGLES>(context.GetReactor(), desc);
-  image->MarkContentsInitialized();
-  image->SetCoordinateSystem(
-      impeller::TextureCoordinateSystem::kUploadFromHost);
-  if (!image->Bind()) {
-    if (texture->destruction_callback) {
-      texture->destruction_callback(texture->user_data);
+    if (texture->destruction_callback &&
+        !context.GetReactor()->RegisterCleanupCallback(
+            handle,
+            [callback = texture->destruction_callback,
+             user_data = texture->user_data]() { callback(user_data); })) {
+      FML_LOG(ERROR) << "Could not register destruction callback";
+      return nullptr;
     }
-    FML_LOG(ERROR) << "Could not bind texture";
-    return nullptr;
-  }
-
-  if (!image) {
-    // In case Skia rejects the image, call the release proc so that
-    // embedders can perform collection of intermediates.
-    if (texture->destruction_callback) {
-      texture->destruction_callback(texture->user_data);
-    }
-    FML_LOG(ERROR) << "Could not create external texture";
-    return nullptr;
-  }
-
-  if (!texture->bind_callback(texture->user_data)) {
-    if (texture->destruction_callback) {
-      texture->destruction_callback(texture->user_data);
-    }
-    return nullptr;
-  }
-
-  if (texture->destruction_callback) {
-    texture->destruction_callback(texture->user_data);
+    impeller_gl_textures_[texture->name] = image;
   }
 
   return impeller::DlImageImpeller::Make(image);

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -35,9 +35,8 @@ std::optional<TextureLRU::Data> TextureLRU::FindTexture(
   auto key_value = key.value();
   for (size_t i = 0u; i < kTextureMaxSize; i++) {
     if (textures_[i].key == key_value) {
-      auto result = textures_[i].value;
       UpdateTexture(Data{.key = key_value,
-                         .value = result,
+                         .texture = textures_[i].texture,
                          .width = textures_[i].width,
                          .height = textures_[i].height});
       return std::make_optional(textures_[i]);
@@ -57,6 +56,11 @@ void TextureLRU::UpdateTexture(Data data) {
       break;
     }
   }
+
+  if (i == kTextureMaxSize) {
+    return;
+  }
+
   for (auto j = i; j > 0; j--) {
     textures_[j] = textures_[j - 1];
   }
@@ -82,7 +86,7 @@ GLuint TextureLRU::AddTexture(Data data) {
 
 void TextureLRU::Clear() {
   for (size_t i = 0u; i < kTextureMaxSize; i++) {
-    textures_[i] = Data{.key = 0u, .value = nullptr};
+    textures_[i] = Data{.key = 0u, .texture = nullptr};
   }
 }
 
@@ -102,7 +106,7 @@ void TextureLRU::RemoveTexture(GLuint key) {
     textures_[i] = textures_[i + 1];
   }
 
-  textures_[kTextureMaxSize - 1] = Data{.key = 0u, .value = nullptr};
+  textures_[kTextureMaxSize - 1] = Data{.key = 0u, .texture = nullptr};
 }
 
 EmbedderExternalTextureGL::EmbedderExternalTextureGL(
@@ -274,16 +278,16 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
   }
 
   if (texture_data.has_value() && !size_change) {
-    return impeller::DlImageImpeller::Make(texture_data.value().value);
+    return impeller::DlImageImpeller::Make(texture_data.value().texture);
   } else if (texture_data.has_value() && size_change) {
     std::shared_ptr<impeller::TextureGLES> old_gles_texture =
-        texture_data.value().value;
+        texture_data.value().texture;
     old_gles_texture->Leak();
     std::shared_ptr<impeller::TextureGLES> new_gles_texture =
         CreateTextureGLES(aiks_context, texture.get());
     if (new_gles_texture) {
       texture_lru_.UpdateTexture(TextureLRU::Data{.key = texture->name,
-                                                  .value = new_gles_texture,
+                                                  .texture = new_gles_texture,
                                                   .width = texture->width,
                                                   .height = texture->height});
 
@@ -297,7 +301,7 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
         CreateTextureGLES(aiks_context, texture.get());
     if (new_gles_texture) {
       texture_lru_.AddTexture(TextureLRU::Data{.key = texture->name,
-                                               .value = new_gles_texture,
+                                               .texture = new_gles_texture,
                                                .width = texture->width,
                                                .height = texture->height});
       return impeller::DlImageImpeller::Make(new_gles_texture);

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_SHELL_PLATFORM_EMBEDDER_EMBEDDER_EXTERNAL_TEXTURE_GL_H_
 #define FLUTTER_SHELL_PLATFORM_EMBEDDER_EMBEDDER_EXTERNAL_TEXTURE_GL_H_
 
+#include <list>
+#include <memory>
 #include <unordered_map>
 #include "flutter/common/graphics/texture.h"
 #include "flutter/fml/macros.h"
@@ -13,6 +15,47 @@
 #include "third_party/skia/include/core/SkSize.h"
 
 namespace flutter {
+static constexpr size_t kTextureMaxSize = 6u;
+
+class TextureLRU {
+ public:
+  struct Data {
+    GLuint key = 0u;
+    std::shared_ptr<impeller::TextureGLES> value;
+    size_t width = 0;
+    size_t height = 0;
+  };
+
+  TextureLRU() = default;
+
+  ~TextureLRU() = default;
+
+  /// @brief Retrieve the Texture associated with the given [key], or nullptr.
+  std::optional<Data> FindTexture(std::optional<GLuint> key);
+
+  /// @brief Add a new texture to the cache with a key, returning the key of the
+  ///        LRU entry that was removed.
+  ///
+  /// The value may be `0`, in which case nothing was removed.
+  GLuint AddTexture(const std::shared_ptr<impeller::TextureGLES>& texture,
+                    GLuint key,
+                    size_t width,
+                    size_t height);
+
+  /// @brief Remove all entires from the image cache.
+  void Clear();
+
+  /// @brief Remove a texture from the cache by key.
+  void RemoveTexture(GLuint key);
+  /// @brief Marks [key] as the most recently used.
+  void UpdateTexture(const std::shared_ptr<impeller::TextureGLES>& texture,
+                     GLuint key,
+                     size_t width,
+                     size_t height);
+
+ private:
+  std::array<Data, kTextureMaxSize> textures_;
+};
 
 class EmbedderExternalTextureGL : public flutter::Texture {
  public:
@@ -27,8 +70,7 @@ class EmbedderExternalTextureGL : public flutter::Texture {
  private:
   const ExternalTextureCallback& external_texture_callback_;
   sk_sp<DlImage> last_image_;
-  std::unordered_map<GLuint, std::shared_ptr<impeller::TextureGLES>>
-      impeller_gl_textures_;
+  TextureLRU texture_lru_ = TextureLRU();
   sk_sp<DlImage> ResolveTexture(int64_t texture_id,
                                 GrDirectContext* context,
                                 impeller::AiksContext* aiks_context,
@@ -41,6 +83,10 @@ class EmbedderExternalTextureGL : public flutter::Texture {
   sk_sp<DlImage> ResolveTextureImpeller(int64_t texture_id,
                                         impeller::AiksContext* aiks_context,
                                         const SkISize& size);
+
+  std::shared_ptr<impeller::TextureGLES> CreateTextureGLES(
+      impeller::AiksContext* aiks_context,
+      FlutterOpenGLTexture* texture);
 
   // |flutter::Texture|
   void Paint(PaintContext& context,

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
@@ -21,7 +21,7 @@ class TextureLRU {
  public:
   struct Data {
     GLuint key = 0u;
-    std::shared_ptr<impeller::TextureGLES> value;
+    std::shared_ptr<impeller::TextureGLES> texture;
     size_t width = 0;
     size_t height = 0;
   };

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
@@ -37,21 +37,16 @@ class TextureLRU {
   ///        LRU entry that was removed.
   ///
   /// The value may be `0`, in which case nothing was removed.
-  GLuint AddTexture(const std::shared_ptr<impeller::TextureGLES>& texture,
-                    GLuint key,
-                    size_t width,
-                    size_t height);
+  GLuint AddTexture(Data data);
 
   /// @brief Remove all entires from the image cache.
   void Clear();
 
   /// @brief Remove a texture from the cache by key.
   void RemoveTexture(GLuint key);
+
   /// @brief Marks [key] as the most recently used.
-  void UpdateTexture(const std::shared_ptr<impeller::TextureGLES>& texture,
-                     GLuint key,
-                     size_t width,
-                     size_t height);
+  void UpdateTexture(Data data);
 
  private:
   std::array<Data, kTextureMaxSize> textures_;

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.h
@@ -5,9 +5,11 @@
 #ifndef FLUTTER_SHELL_PLATFORM_EMBEDDER_EMBEDDER_EXTERNAL_TEXTURE_GL_H_
 #define FLUTTER_SHELL_PLATFORM_EMBEDDER_EMBEDDER_EXTERNAL_TEXTURE_GL_H_
 
+#include <unordered_map>
 #include "flutter/common/graphics/texture.h"
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/embedder/embedder.h"
+#include "impeller/renderer/backend/gles/texture_gles.h"
 #include "third_party/skia/include/core/SkSize.h"
 
 namespace flutter {
@@ -25,7 +27,8 @@ class EmbedderExternalTextureGL : public flutter::Texture {
  private:
   const ExternalTextureCallback& external_texture_callback_;
   sk_sp<DlImage> last_image_;
-
+  std::unordered_map<GLuint, std::shared_ptr<impeller::TextureGLES>>
+      impeller_gl_textures_;
   sk_sp<DlImage> ResolveTexture(int64_t texture_id,
                                 GrDirectContext* context,
                                 impeller::AiksContext* aiks_context,
@@ -38,14 +41,6 @@ class EmbedderExternalTextureGL : public flutter::Texture {
   sk_sp<DlImage> ResolveTextureImpeller(int64_t texture_id,
                                         impeller::AiksContext* aiks_context,
                                         const SkISize& size);
-
-  sk_sp<DlImage> ResolveTextureImpellerPixelbuffer(
-      impeller::AiksContext* aiks_context,
-      std::unique_ptr<FlutterOpenGLTexture> texture);
-
-  sk_sp<DlImage> ResolveTextureImpellerSurface(
-      impeller::AiksContext* aiks_context,
-      std::unique_ptr<FlutterOpenGLTexture> texture);
 
   // |flutter::Texture|
   void Paint(PaintContext& context,


### PR DESCRIPTION
We have supported render external texture gl for Impeller
https://github.com/flutter-tizen/engine/pull/368
But this PR has two issues:
1. It modify FlutterOpenGLTexture, it added additional variables, not a good design.
```C++
  /// The pixel data buffer.
  const uint8_t* buffer;
  /// The size of pixel buffer.
  size_t buffer_size;
  /// Callback invoked that the gpu surface texture start binding.
  BoolCallback bind_callback;
  /// The type of the texture.
  FlutterGLImpellerTextureType impeller_texture_type;
```
2. It uses Deprecated API
```C++
  // Deprecated: use BlitPass::AddCopy instead.
  [[nodiscard]] bool SetContents(const uint8_t* contents,
                                 size_t length,
                                 size_t slice = 0,
                                 bool is_opaque = false);

```

So I tried to revert offical PR to render external gl for impeller
https://github.com/flutter/engine/pull/56277
But this PR doesn't work on Tizen platform, I think This PR may not have been verified.
To avoid change FlutterOpenGLTexture and use deprecated api, so I re-implemented render external texture gl for impeller based on this offical PR.
Fix https://github.com/flutter-tizen/embedder/issues/131