### PR TITLE
[Tizen] CI host artifact builds for macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,7 @@ jobs:
 
     strategy:
       matrix:
-        arch: [arm, arm64]
+        arch: [arm, arm64, x64]
         mode: [release, profile]
 
     steps:
@@ -273,7 +273,7 @@ jobs:
 
     strategy:
       matrix:
-        arch: [arm, arm64]
+        arch: [arm, arm64, x64]
         mode: [release, profile]
 
     steps:
@@ -326,7 +326,7 @@ jobs:
           if-no-files-found: error
 
   release:
-    needs: [build]
+    needs: [build, macos-build, macos-intel-build]
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Adds artifact generation for x64 builds in a macOS environment.
I tested the build on macOS 26.3 (Tahoe) and M4 Pro (Arm64) using the x64 lib