### PR TITLE
[Tizen] CI host artifact builds for Windows x64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
 
     strategy:
       matrix:
-        arch: [arm, arm64]
+        arch: [arm, arm64, x64]
         mode: [release, profile]
 
     steps:
@@ -326,7 +326,7 @@ jobs:
           if-no-files-found: error
 
   release:
-    needs: [build, macos-build, macos-intel-build]
+    needs: [build, windows-build, macos-build, macos-intel-build]
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Adds artifact generation for x64 builds in a windows environment.
I tested the build on window 11 using the x64 lib