### PR TITLE
[Impeller] Use the IO context for OpenGL program setup

### DIFF
--- a/engine/src/flutter/impeller/renderer/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/BUILD.gn
@@ -104,6 +104,7 @@ template("renderer_unittests_component") {
     "blit_pass_unittests.cc",
     "capabilities_unittests.cc",
     "device_buffer_unittests.cc",
+    "pipeline_compile_queue_unittests.cc",
     "pipeline_descriptor_unittests.cc",
     "pipeline_library_unittests.cc",
     "pool_unittests.cc",

--- a/engine/src/flutter/impeller/renderer/backend/gles/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/gles/BUILD.gn
@@ -24,6 +24,7 @@ impeller_component("gles_unittests") {
     "test/mock_gles.cc",
     "test/mock_gles.h",
     "test/mock_gles_unittests.cc",
+    "test/pipeline_compile_queue_gles_unittests.cc",
     "test/pipeline_library_gles_unittests.cc",
     "test/proc_table_gles_unittests.cc",
     "test/reactor_unittests.cc",
@@ -34,6 +35,7 @@ impeller_component("gles_unittests") {
   ]
   deps = [
     ":gles",
+    "//flutter/fml",
     "//flutter/impeller/playground:playground_test",
     "//flutter/testing:testing_lib",
   ]

--- a/engine/src/flutter/impeller/renderer/backend/gles/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/gles/BUILD.gn
@@ -68,6 +68,8 @@ impeller_component("gles") {
     "gpu_tracer_gles.h",
     "handle_gles.cc",
     "handle_gles.h",
+    "pipeline_compile_queue_gles.cc",
+    "pipeline_compile_queue_gles.h",
     "pipeline_gles.cc",
     "pipeline_gles.h",
     "pipeline_library_gles.cc",

--- a/engine/src/flutter/impeller/renderer/backend/gles/context_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/context_gles.cc
@@ -22,16 +22,19 @@ std::shared_ptr<ContextGLES> ContextGLES::Create(
     const Flags& flags,
     std::unique_ptr<ProcTableGLES> gl,
     const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries,
-    bool enable_gpu_tracing) {
-  return std::shared_ptr<ContextGLES>(new ContextGLES(
-      flags, std::move(gl), shader_libraries, enable_gpu_tracing));
+    bool enable_gpu_tracing,
+    fml::RefPtr<fml::TaskRunner> io_task_runner) {
+  return std::shared_ptr<ContextGLES>(
+      new ContextGLES(flags, std::move(gl), shader_libraries,
+                      enable_gpu_tracing, std::move(io_task_runner)));
 }
 
 ContextGLES::ContextGLES(
     const Flags& flags,
     std::unique_ptr<ProcTableGLES> gl,
     const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries_mappings,
-    bool enable_gpu_tracing)
+    bool enable_gpu_tracing,
+    fml::RefPtr<fml::TaskRunner> io_task_runner)
     : Context(flags) {
   reactor_ = std::make_shared<ReactorGLES>(std::move(gl));
   if (!reactor_->IsValid()) {
@@ -52,8 +55,8 @@ ContextGLES::ContextGLES(
 
   // Create the pipeline library.
   {
-    pipeline_library_ =
-        std::shared_ptr<PipelineLibraryGLES>(new PipelineLibraryGLES(reactor_));
+    pipeline_library_ = std::shared_ptr<PipelineLibraryGLES>(
+        new PipelineLibraryGLES(reactor_, std::move(io_task_runner)));
   }
 
   // Create allocators.

--- a/engine/src/flutter/impeller/renderer/backend/gles/context_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/context_gles.h
@@ -28,7 +28,8 @@ class ContextGLES final : public Context,
       const Flags& flags,
       std::unique_ptr<ProcTableGLES> gl,
       const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries,
-      bool enable_gpu_tracing);
+      bool enable_gpu_tracing,
+      fml::RefPtr<fml::TaskRunner> io_task_runner = nullptr);
 
   // |Context|
   ~ContextGLES() override;
@@ -64,7 +65,8 @@ class ContextGLES final : public Context,
       const Flags& flags,
       std::unique_ptr<ProcTableGLES> gl,
       const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries,
-      bool enable_gpu_tracing);
+      bool enable_gpu_tracing,
+      fml::RefPtr<fml::TaskRunner> io_task_runner);
 
   // |Context|
   std::string DescribeGpuModel() const override;

--- a/engine/src/flutter/impeller/renderer/backend/gles/context_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/context_gles.h
@@ -66,7 +66,7 @@ class ContextGLES final : public Context,
       std::unique_ptr<ProcTableGLES> gl,
       const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries,
       bool enable_gpu_tracing,
-      fml::RefPtr<fml::TaskRunner> io_task_runner);
+      fml::RefPtr<fml::TaskRunner> io_task_runner = nullptr);
 
   // |Context|
   std::string DescribeGpuModel() const override;

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
@@ -19,13 +19,6 @@ PipelineCompileQueueGLES::PipelineCompileQueueGLES(
     fml::RefPtr<fml::TaskRunner> worker_task_runner)
     : worker_task_runner_(std::move(worker_task_runner)) {}
 
-// The base class destructor calls FinishAllJobs() which drains any remaining
-// pending jobs on the current thread. If a ProcessJobsSequentially task is
-// still in flight on the IO thread, the weak_from_this() capture in the
-// posted lambda will safely return nullptr and the task will be a no-op.
-// Any jobs already taken from the queue by the IO thread will still execute,
-// but this is safe because they capture weak references to the pipeline
-// library (not to this compile queue).
 PipelineCompileQueueGLES::~PipelineCompileQueueGLES() = default;
 
 void PipelineCompileQueueGLES::OnJobAdded() {

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
@@ -19,41 +19,14 @@ PipelineCompileQueueGLES::PipelineCompileQueueGLES(
     fml::RefPtr<fml::TaskRunner> task_runner)
     : PipelineCompileQueue(nullptr), task_runner_(std::move(task_runner)) {}
 
-PipelineCompileQueueGLES::~PipelineCompileQueueGLES() {
-  FinishAllJobs();
-}
+PipelineCompileQueueGLES::~PipelineCompileQueueGLES() {}
 
-bool PipelineCompileQueueGLES::PostJobForDescriptor(
-    const PipelineDescriptor& desc,
-    const fml::closure& job) {
+void PipelineCompileQueueGLES::PostJob(const fml::closure& job) {
   if (!job) {
-    return false;
+    return;
   }
 
-  {
-    Lock lock(pending_jobs_mutex_);
-    auto insertion_result = pending_jobs_.insert(std::make_pair(desc, job));
-    if (!insertion_result.second) {
-      // This bit is being extremely conservative. If insertion did not take
-      // place, someone gave the compile queue a job for the same description.
-      // This is highly unusual but technically not impossible. Just run the job
-      // eagerly.
-      FML_LOG(ERROR) << "Got multiple compile jobs for the same descriptor. "
-                        "Running eagerly.";
-      // Don't invoke the job here has there are we have currently acquired a
-      // mutex.
-      task_runner_->PostTask(job);
-      return true;
-    }
-  }
-
-  task_runner_->PostTask([weak_queue = weak_from_this()]() {
-    if (auto queue = std::static_pointer_cast<PipelineCompileQueueGLES>(
-            weak_queue.lock())) {
-      queue->DoOneJob();
-    }
-  });
-  return true;
+  task_runner_->PostTask(job);
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
@@ -11,6 +11,9 @@ namespace impeller {
 
 std::shared_ptr<PipelineCompileQueueGLES> PipelineCompileQueueGLES::Create(
     fml::RefPtr<fml::TaskRunner> worker_task_runner) {
+  if (!worker_task_runner) {
+    return nullptr;
+  }
   return std::shared_ptr<PipelineCompileQueueGLES>(
       new PipelineCompileQueueGLES(std::move(worker_task_runner)));
 }
@@ -33,14 +36,8 @@ void PipelineCompileQueueGLES::PostJob(const fml::closure& job) {
   if (!job) {
     return;
   }
-  if (worker_task_runner_) {
-    worker_task_runner_->PostTask(job);
-  } else {
-    // No task runner available, execute synchronously on the current thread.
-    // This is safe in Playground/test environments where the current thread
-    // is the GL thread.
-    job();
-  }
+
+  worker_task_runner_->PostTask(job);
 }
 
 void PipelineCompileQueueGLES::ProcessJobsSequentially() {

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
@@ -10,14 +10,15 @@
 namespace impeller {
 
 std::shared_ptr<PipelineCompileQueueGLES> PipelineCompileQueueGLES::Create(
-    fml::RefPtr<fml::TaskRunner> task_runner) {
+    fml::RefPtr<fml::TaskRunner> worker_task_runner) {
   return std::shared_ptr<PipelineCompileQueueGLES>(
-      new PipelineCompileQueueGLES(std::move(task_runner)));
+      new PipelineCompileQueueGLES(std::move(worker_task_runner)));
 }
 
 PipelineCompileQueueGLES::PipelineCompileQueueGLES(
-    fml::RefPtr<fml::TaskRunner> task_runner)
-    : PipelineCompileQueue(nullptr), task_runner_(std::move(task_runner)) {}
+    fml::RefPtr<fml::TaskRunner> worker_task_runner)
+    : PipelineCompileQueue(),
+      worker_task_runner_(std::move(worker_task_runner)) {}
 
 PipelineCompileQueueGLES::~PipelineCompileQueueGLES() {}
 
@@ -26,7 +27,7 @@ void PipelineCompileQueueGLES::PostJob(const fml::closure& job) {
     return;
   }
 
-  task_runner_->PostTask(job);
+  worker_task_runner_->PostTask(job);
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
@@ -26,11 +26,11 @@ PipelineCompileQueueGLES::PipelineCompileQueueGLES(
 PipelineCompileQueueGLES::~PipelineCompileQueueGLES() = default;
 
 void PipelineCompileQueueGLES::OnJobAdded() {
-  /// To prevent potential deadlocks and reduce lock contention, avoid calling
-  /// external or virtual methods (such as DrainPendingJobs, which posts tasks
-  /// to the task runner) while holding a mutex. Instead, minimize the scope of
-  /// the lock by using a local boolean flag to trigger the draining process
-  /// outside the lock block.
+  // To prevent potential deadlocks and reduce lock contention, avoid calling
+  // external or virtual methods (such as DrainPendingJobs, which posts tasks
+  // to the task runner) while holding a mutex. Instead, minimize the scope of
+  // the lock by using a local boolean flag to trigger the draining process
+  // outside the lock block.
   bool should_drain = false;
   {
     Lock lock(processing_mutex_);

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
@@ -17,10 +17,34 @@ std::shared_ptr<PipelineCompileQueueGLES> PipelineCompileQueueGLES::Create(
 
 PipelineCompileQueueGLES::PipelineCompileQueueGLES(
     fml::RefPtr<fml::TaskRunner> worker_task_runner)
-    : PipelineCompileQueue(true),
-      worker_task_runner_(std::move(worker_task_runner)) {}
+    : worker_task_runner_(std::move(worker_task_runner)) {}
 
 PipelineCompileQueueGLES::~PipelineCompileQueueGLES() {}
+
+bool PipelineCompileQueueGLES::PostJobForDescriptor(
+    const PipelineDescriptor& desc,
+    const fml::closure& job) {
+  if (!job) {
+    return false;
+  }
+
+  if (!AddJob(desc, job)) {
+    // This bit is being extremely conservative. If insertion did not take
+    // place, someone gave the compile queue a job for the same description.
+    // This is highly unusual but technically not impossible. Just run the job
+    // eagerly.
+    FML_LOG(ERROR) << "Got multiple compile jobs for the same descriptor. "
+                      "Running eagerly.";
+    PostJob(job);
+    return true;
+  }
+
+  bool expected = false;
+  if (is_processing_.compare_exchange_strong(expected, true)) {
+    ProcessJobsSequentially();
+  }
+  return true;
+}
 
 void PipelineCompileQueueGLES::PostJob(const fml::closure& job) {
   if (!job) {
@@ -28,6 +52,20 @@ void PipelineCompileQueueGLES::PostJob(const fml::closure& job) {
   }
 
   worker_task_runner_->PostTask(job);
+}
+
+void PipelineCompileQueueGLES::ProcessJobsSequentially() {
+  PostJob([weak_queue = weak_from_this()]() {
+    if (auto queue = std::static_pointer_cast<PipelineCompileQueueGLES>(
+            weak_queue.lock())) {
+      queue->DoOneJob();
+      if (!queue->HasPendingJobs()) {
+        queue->is_processing_ = false;
+        return;
+      }
+      queue->ProcessJobsSequentially();
+    }
+  });
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
@@ -39,8 +39,9 @@ bool PipelineCompileQueueGLES::PostJobForDescriptor(
     return true;
   }
 
-  bool expected = false;
-  if (is_processing_.compare_exchange_strong(expected, true)) {
+  std::scoped_lock lock(processing_mutex_);
+  if (!is_processing_) {
+    is_processing_ = true;
     ProcessJobsSequentially();
   }
   return true;
@@ -59,9 +60,12 @@ void PipelineCompileQueueGLES::ProcessJobsSequentially() {
     if (auto queue = std::static_pointer_cast<PipelineCompileQueueGLES>(
             weak_queue.lock())) {
       queue->DoOneJob();
-      if (!queue->HasPendingJobs()) {
-        queue->is_processing_ = false;
-        return;
+      {
+        std::scoped_lock lock(queue->processing_mutex_);
+        if (!queue->HasPendingJobs()) {
+          queue->is_processing_ = false;
+          return;
+        }
       }
       queue->ProcessJobsSequentially();
     }

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
@@ -17,7 +17,7 @@ std::shared_ptr<PipelineCompileQueueGLES> PipelineCompileQueueGLES::Create(
 
 PipelineCompileQueueGLES::PipelineCompileQueueGLES(
     fml::RefPtr<fml::TaskRunner> worker_task_runner)
-    : PipelineCompileQueue(),
+    : PipelineCompileQueue(true),
       worker_task_runner_(std::move(worker_task_runner)) {}
 
 PipelineCompileQueueGLES::~PipelineCompileQueueGLES() {}

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
@@ -1,0 +1,59 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/backend/gles/pipeline_compile_queue_gles.h"
+
+#include "flutter/fml/logging.h"
+#include "flutter/fml/trace_event.h"
+
+namespace impeller {
+
+std::shared_ptr<PipelineCompileQueueGLES> PipelineCompileQueueGLES::Create(
+    fml::RefPtr<fml::TaskRunner> task_runner) {
+  return std::shared_ptr<PipelineCompileQueueGLES>(
+      new PipelineCompileQueueGLES(std::move(task_runner)));
+}
+
+PipelineCompileQueueGLES::PipelineCompileQueueGLES(
+    fml::RefPtr<fml::TaskRunner> task_runner)
+    : PipelineCompileQueue(nullptr), task_runner_(std::move(task_runner)) {}
+
+PipelineCompileQueueGLES::~PipelineCompileQueueGLES() {
+  FinishAllJobs();
+}
+
+bool PipelineCompileQueueGLES::PostJobForDescriptor(
+    const PipelineDescriptor& desc,
+    const fml::closure& job) {
+  if (!job) {
+    return false;
+  }
+
+  {
+    Lock lock(pending_jobs_mutex_);
+    auto insertion_result = pending_jobs_.insert(std::make_pair(desc, job));
+    if (!insertion_result.second) {
+      // This bit is being extremely conservative. If insertion did not take
+      // place, someone gave the compile queue a job for the same description.
+      // This is highly unusual but technically not impossible. Just run the job
+      // eagerly.
+      FML_LOG(ERROR) << "Got multiple compile jobs for the same descriptor. "
+                        "Running eagerly.";
+      // Don't invoke the job here has there are we have currently acquired a
+      // mutex.
+      task_runner_->PostTask(job);
+      return true;
+    }
+  }
+
+  task_runner_->PostTask([weak_queue = weak_from_this()]() {
+    if (auto queue = std::static_pointer_cast<PipelineCompileQueueGLES>(
+            weak_queue.lock())) {
+      queue->DoOneJob();
+    }
+  });
+  return true;
+}
+
+}  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
@@ -19,40 +19,35 @@ PipelineCompileQueueGLES::PipelineCompileQueueGLES(
     fml::RefPtr<fml::TaskRunner> worker_task_runner)
     : worker_task_runner_(std::move(worker_task_runner)) {}
 
-PipelineCompileQueueGLES::~PipelineCompileQueueGLES() {}
+// The base class destructor calls FinishAllJobs() which drains any remaining
+// pending jobs on the current thread. If a ProcessJobsSequentially task is
+// still in flight on the IO thread, the weak_from_this() capture in the
+// posted lambda will safely return nullptr and the task will be a no-op.
+// Any jobs already taken from the queue by the IO thread will still execute,
+// but this is safe because they capture weak references to the pipeline
+// library (not to this compile queue).
+PipelineCompileQueueGLES::~PipelineCompileQueueGLES() = default;
 
-bool PipelineCompileQueueGLES::PostJobForDescriptor(
-    const PipelineDescriptor& desc,
-    const fml::closure& job) {
-  if (!job) {
-    return false;
-  }
-
-  if (!AddJob(desc, job)) {
-    // This bit is being extremely conservative. If insertion did not take
-    // place, someone gave the compile queue a job for the same description.
-    // This is highly unusual but technically not impossible. Just run the job
-    // eagerly.
-    FML_LOG(ERROR) << "Got multiple compile jobs for the same descriptor. "
-                      "Running eagerly.";
-    PostJob(job);
-    return true;
-  }
-
-  std::scoped_lock lock(processing_mutex_);
+void PipelineCompileQueueGLES::OnJobAdded() {
+  Lock lock(processing_mutex_);
   if (!is_processing_) {
     is_processing_ = true;
     ProcessJobsSequentially();
   }
-  return true;
 }
 
 void PipelineCompileQueueGLES::PostJob(const fml::closure& job) {
   if (!job) {
     return;
   }
-
-  worker_task_runner_->PostTask(job);
+  if (worker_task_runner_) {
+    worker_task_runner_->PostTask(job);
+  } else {
+    // No task runner available, execute synchronously on the current thread.
+    // This is safe in Playground/test environments where the current thread
+    // is the GL thread.
+    job();
+  }
 }
 
 void PipelineCompileQueueGLES::ProcessJobsSequentially() {
@@ -61,7 +56,7 @@ void PipelineCompileQueueGLES::ProcessJobsSequentially() {
             weak_queue.lock())) {
       queue->DoOneJob();
       {
-        std::scoped_lock lock(queue->processing_mutex_);
+        Lock lock(queue->processing_mutex_);
         if (!queue->HasPendingJobs()) {
           queue->is_processing_ = false;
           return;

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
@@ -6,6 +6,7 @@
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"
+#include "impeller/base/validation.h"
 
 namespace impeller {
 
@@ -28,7 +29,7 @@ void PipelineCompileQueueGLES::OnJobAdded() {
   Lock lock(processing_mutex_);
   if (!is_processing_) {
     is_processing_ = true;
-    ProcessJobsSequentially();
+    DrainPendingJobs();
   }
 }
 
@@ -40,7 +41,7 @@ void PipelineCompileQueueGLES::PostJob(const fml::closure& job) {
   worker_task_runner_->PostTask(job);
 }
 
-void PipelineCompileQueueGLES::ProcessJobsSequentially() {
+void PipelineCompileQueueGLES::DrainPendingJobs() {
   PostJob([weak_queue = weak_from_this()]() {
     if (auto queue = std::static_pointer_cast<PipelineCompileQueueGLES>(
             weak_queue.lock())) {
@@ -52,7 +53,7 @@ void PipelineCompileQueueGLES::ProcessJobsSequentially() {
           return;
         }
       }
-      queue->ProcessJobsSequentially();
+      queue->DrainPendingJobs();
     }
   });
 }

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.cc
@@ -26,9 +26,20 @@ PipelineCompileQueueGLES::PipelineCompileQueueGLES(
 PipelineCompileQueueGLES::~PipelineCompileQueueGLES() = default;
 
 void PipelineCompileQueueGLES::OnJobAdded() {
-  Lock lock(processing_mutex_);
-  if (!is_processing_) {
-    is_processing_ = true;
+  /// To prevent potential deadlocks and reduce lock contention, avoid calling
+  /// external or virtual methods (such as DrainPendingJobs, which posts tasks
+  /// to the task runner) while holding a mutex. Instead, minimize the scope of
+  /// the lock by using a local boolean flag to trigger the draining process
+  /// outside the lock block.
+  bool should_drain = false;
+  {
+    Lock lock(processing_mutex_);
+    if (!is_processing_) {
+      is_processing_ = true;
+      should_drain = true;
+    }
+  }
+  if (should_drain) {
     DrainPendingJobs();
   }
 }

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_GLES_PIPELINE_COMPILE_QUEUE_GLES_H_
 
 #include <atomic>
+#include <mutex>
 
 #include "flutter/fml/closure.h"
 #include "flutter/fml/task_runner.h"
@@ -50,7 +51,8 @@ class PipelineCompileQueueGLES : public PipelineCompileQueue {
 
  private:
   fml::RefPtr<fml::TaskRunner> worker_task_runner_;
-  std::atomic<bool> is_processing_{false};
+  std::mutex processing_mutex_;
+  std::atomic<bool> is_processing_ = false;
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
@@ -5,11 +5,9 @@
 #ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_GLES_PIPELINE_COMPILE_QUEUE_GLES_H_
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_GLES_PIPELINE_COMPILE_QUEUE_GLES_H_
 
-#include <atomic>
-#include <mutex>
-
 #include "flutter/fml/closure.h"
 #include "flutter/fml/task_runner.h"
+#include "impeller/base/thread.h"
 #include "impeller/renderer/pipeline_compile_queue.h"
 
 namespace impeller {
@@ -29,30 +27,24 @@ class PipelineCompileQueueGLES : public PipelineCompileQueue {
   PipelineCompileQueueGLES& operator=(const PipelineCompileQueueGLES&) = delete;
 
   //----------------------------------------------------------------------------
-  /// @brief      Post a compile job for the specified descriptor.
-  ///
-  /// @param[in]  desc  The description
-  /// @param[in]  job   The job
-  ///
-  /// @return     If the job was successfully posted to the parallel task
-  /// runners.
-  ///
-  bool PostJobForDescriptor(const PipelineDescriptor& desc,
-                            const fml::closure& job) override;
-
-  //----------------------------------------------------------------------------
   /// @brief      Post a job to the worker task runner.
   ///
   /// @param[in]  job   The job
   ///
   void PostJob(const fml::closure& job) override;
 
-  void ProcessJobsSequentially();
+  //----------------------------------------------------------------------------
+  /// @brief      Called after a job has been added to the queue. Implements
+  ///             the sequential scheduling strategy for GLES.
+  ///
+  void OnJobAdded() override;
 
  private:
+  void ProcessJobsSequentially();
+
   fml::RefPtr<fml::TaskRunner> worker_task_runner_;
-  std::mutex processing_mutex_;
-  bool is_processing_ = false;
+  Mutex processing_mutex_;
+  bool is_processing_ IPLR_GUARDED_BY(processing_mutex_) = false;
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
@@ -40,7 +40,7 @@ class PipelineCompileQueueGLES : public PipelineCompileQueue {
   void OnJobAdded() override;
 
  private:
-  void ProcessJobsSequentially();
+  void DrainPendingJobs();
 
   fml::RefPtr<fml::TaskRunner> worker_task_runner_;
   Mutex processing_mutex_;

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_GLES_PIPELINE_COMPILE_QUEUE_GLES_H_
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_GLES_PIPELINE_COMPILE_QUEUE_GLES_H_
 
+#include <atomic>
+
 #include "flutter/fml/closure.h"
 #include "flutter/fml/task_runner.h"
 #include "impeller/renderer/pipeline_compile_queue.h"
@@ -26,14 +28,29 @@ class PipelineCompileQueueGLES : public PipelineCompileQueue {
   PipelineCompileQueueGLES& operator=(const PipelineCompileQueueGLES&) = delete;
 
   //----------------------------------------------------------------------------
+  /// @brief      Post a compile job for the specified descriptor.
+  ///
+  /// @param[in]  desc  The description
+  /// @param[in]  job   The job
+  ///
+  /// @return     If the job was successfully posted to the parallel task
+  /// runners.
+  ///
+  bool PostJobForDescriptor(const PipelineDescriptor& desc,
+                            const fml::closure& job) override;
+
+  //----------------------------------------------------------------------------
   /// @brief      Post a job to the worker task runner.
   ///
   /// @param[in]  job   The job
   ///
   void PostJob(const fml::closure& job) override;
 
+  void ProcessJobsSequentially();
+
  private:
   fml::RefPtr<fml::TaskRunner> worker_task_runner_;
+  std::atomic<bool> is_processing_{false};
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
@@ -1,0 +1,45 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_GLES_PIPELINE_COMPILE_QUEUE_GLES_H_
+#define FLUTTER_IMPELLER_RENDERER_BACKEND_GLES_PIPELINE_COMPILE_QUEUE_GLES_H_
+
+#include "flutter/fml/closure.h"
+#include "flutter/fml/task_runner.h"
+#include "impeller/renderer/pipeline_compile_queue.h"
+
+namespace impeller {
+
+class PipelineCompileQueueGLES : public PipelineCompileQueue {
+ public:
+  static std::shared_ptr<PipelineCompileQueueGLES> Create(
+      fml::RefPtr<fml::TaskRunner> task_runner);
+
+  explicit PipelineCompileQueueGLES(fml::RefPtr<fml::TaskRunner> task_runner);
+
+  ~PipelineCompileQueueGLES() override;
+
+  PipelineCompileQueueGLES(const PipelineCompileQueueGLES&) = delete;
+
+  PipelineCompileQueueGLES& operator=(const PipelineCompileQueueGLES&) = delete;
+
+  //----------------------------------------------------------------------------
+  /// @brief      Post a compile job for the specified descriptor.
+  ///
+  /// @param[in]  desc  The description
+  /// @param[in]  job   The job
+  ///
+  /// @return     If the job was successfully posted to the parallel task
+  /// runners.
+  ///
+  bool PostJobForDescriptor(const PipelineDescriptor& desc,
+                            const fml::closure& job) override;
+
+ private:
+  fml::RefPtr<fml::TaskRunner> task_runner_;
+};
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_RENDERER_BACKEND_GLES_PIPELINE_COMPILE_QUEUE_GLES_H_

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
@@ -25,16 +25,14 @@ class PipelineCompileQueueGLES : public PipelineCompileQueue {
   PipelineCompileQueueGLES& operator=(const PipelineCompileQueueGLES&) = delete;
 
   //----------------------------------------------------------------------------
-  /// @brief      Post a compile job for the specified descriptor.
+  /// @brief      Post a job to the worker task runner.
   ///
-  /// @param[in]  desc  The description
   /// @param[in]  job   The job
   ///
   /// @return     If the job was successfully posted to the parallel task
-  /// runners.
+  ///             runners.
   ///
-  bool PostJobForDescriptor(const PipelineDescriptor& desc,
-                            const fml::closure& job) override;
+  void PostJob(const fml::closure& job) override;
 
  private:
   fml::RefPtr<fml::TaskRunner> task_runner_;

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
@@ -26,17 +26,8 @@ class PipelineCompileQueueGLES : public PipelineCompileQueue {
 
   PipelineCompileQueueGLES& operator=(const PipelineCompileQueueGLES&) = delete;
 
-  //----------------------------------------------------------------------------
-  /// @brief      Post a job to the worker task runner.
-  ///
-  /// @param[in]  job   The job
-  ///
   void PostJob(const fml::closure& job) override;
 
-  //----------------------------------------------------------------------------
-  /// @brief      Called after a job has been added to the queue. Implements
-  ///             the sequential scheduling strategy for GLES.
-  ///
   void OnJobAdded() override;
 
  private:

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
@@ -17,9 +17,6 @@ class PipelineCompileQueueGLES : public PipelineCompileQueue {
   static std::shared_ptr<PipelineCompileQueueGLES> Create(
       fml::RefPtr<fml::TaskRunner> worker_task_runner);
 
-  explicit PipelineCompileQueueGLES(
-      fml::RefPtr<fml::TaskRunner> worker_task_runner);
-
   ~PipelineCompileQueueGLES() override;
 
   PipelineCompileQueueGLES(const PipelineCompileQueueGLES&) = delete;
@@ -31,6 +28,8 @@ class PipelineCompileQueueGLES : public PipelineCompileQueue {
   void OnJobAdded() override;
 
  private:
+  explicit PipelineCompileQueueGLES(
+      fml::RefPtr<fml::TaskRunner> worker_task_runner);
   void DrainPendingJobs();
 
   fml::RefPtr<fml::TaskRunner> worker_task_runner_;

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
@@ -12,6 +12,27 @@
 
 namespace impeller {
 
+//------------------------------------------------------------------------------
+/// @brief      A task queue designed for managing compilation of pipeline state
+///             objects for OpenGL ES backend.
+///
+///             This subclass uses a fml::TaskRunner as the worker task runner
+///             and implements a sequential job processing mechanism to prevent
+///             blocking the IO task runner.
+///
+///             Key characteristics:
+///             - Uses fml::RefPtr<fml::TaskRunner> for worker_task_runner_
+///             - Processes jobs sequentially: loads one job at a time before
+///               proceeding to the next, preventing IO task runner blocking
+///             - Uses DrainPendingJobs() to recursively process jobs one by one
+///             - Employs is_processing_ flag and processing_mutex_ to control
+///               sequential processing
+///
+///             The sequential processing ensures that pipeline compilation jobs
+///             do not overwhelm the task runner, which is particularly
+///             important for GLES backend where resource loading patterns
+///             differ from Vulkan.
+///
 class PipelineCompileQueueGLES : public PipelineCompileQueue {
  public:
   static std::shared_ptr<PipelineCompileQueueGLES> Create(

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
@@ -52,7 +52,7 @@ class PipelineCompileQueueGLES : public PipelineCompileQueue {
  private:
   fml::RefPtr<fml::TaskRunner> worker_task_runner_;
   std::mutex processing_mutex_;
-  std::atomic<bool> is_processing_ = false;
+  bool is_processing_ = false;
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_compile_queue_gles.h
@@ -14,9 +14,10 @@ namespace impeller {
 class PipelineCompileQueueGLES : public PipelineCompileQueue {
  public:
   static std::shared_ptr<PipelineCompileQueueGLES> Create(
-      fml::RefPtr<fml::TaskRunner> task_runner);
+      fml::RefPtr<fml::TaskRunner> worker_task_runner);
 
-  explicit PipelineCompileQueueGLES(fml::RefPtr<fml::TaskRunner> task_runner);
+  explicit PipelineCompileQueueGLES(
+      fml::RefPtr<fml::TaskRunner> worker_task_runner);
 
   ~PipelineCompileQueueGLES() override;
 
@@ -29,13 +30,10 @@ class PipelineCompileQueueGLES : public PipelineCompileQueue {
   ///
   /// @param[in]  job   The job
   ///
-  /// @return     If the job was successfully posted to the parallel task
-  ///             runners.
-  ///
   void PostJob(const fml::closure& job) override;
 
  private:
-  fml::RefPtr<fml::TaskRunner> task_runner_;
+  fml::RefPtr<fml::TaskRunner> worker_task_runner_;
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.cc
@@ -20,7 +20,8 @@ PipelineLibraryGLES::PipelineLibraryGLES(
     std::shared_ptr<ReactorGLES> reactor,
     fml::RefPtr<fml::TaskRunner> io_task_runner)
     : reactor_(std::move(reactor)),
-      compile_queue_(PipelineCompileQueueGLES::Create(std::move(io_task_runner))) {}
+      compile_queue_(
+          PipelineCompileQueueGLES::Create(std::move(io_task_runner))) {}
 
 static std::string GetShaderInfoLog(const ProcTableGLES& gl, GLuint shader) {
   GLint log_length = 0;

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.cc
@@ -16,8 +16,11 @@
 
 namespace impeller {
 
-PipelineLibraryGLES::PipelineLibraryGLES(std::shared_ptr<ReactorGLES> reactor)
-    : reactor_(std::move(reactor)) {}
+PipelineLibraryGLES::PipelineLibraryGLES(
+    std::shared_ptr<ReactorGLES> reactor,
+    fml::RefPtr<fml::TaskRunner> io_task_runner)
+    : reactor_(std::move(reactor)),
+      io_task_runner_(std::move(io_task_runner)) {}
 
 static std::string GetShaderInfoLog(const ProcTableGLES& gl, GLuint shader) {
   GLint log_length = 0;

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.cc
@@ -300,17 +300,34 @@ PipelineFuture<PipelineDescriptor> PipelineLibraryGLES::GetPipeline(
       PipelineFuture<PipelineDescriptor>{descriptor, promise->get_future()};
   pipelines_[descriptor] = pipeline_future;
 
-  const auto result = reactor_->AddOperation([promise,                       //
-                                              weak_this = weak_from_this(),  //
-                                              descriptor,                    //
-                                              vert_function,                 //
-                                              frag_function,                 //
-                                              threadsafe                     //
-  ](const ReactorGLES& reactor) {
-    promise->set_value(CreatePipeline(weak_this, descriptor, vert_function,
-                                      frag_function, threadsafe));
-  });
-  FML_CHECK(result);
+  auto weak_this = weak_from_this();
+  auto reactor = reactor_;
+  auto generation_task = [promise, weak_this, descriptor, vert_function,
+                          frag_function, threadsafe, reactor]() {
+    auto thiz = weak_this.lock();
+    if (!thiz) {
+      promise->set_value(nullptr);
+      return;
+    }
+    const auto result = reactor->AddOperation([promise,        //
+                                               weak_this,      //
+                                               descriptor,     //
+                                               vert_function,  //
+                                               frag_function,  //
+                                               threadsafe      //
+    ](const ReactorGLES& reactor) {
+      promise->set_value(CreatePipeline(weak_this, descriptor, vert_function,
+                                        frag_function, threadsafe));
+    });
+    FML_CHECK(result);
+  };
+
+  if (async) {
+    compile_queue_->PostJobForDescriptor(descriptor,
+                                         std::move(generation_task));
+  } else {
+    generation_task();
+  }
 
   return pipeline_future;
 }

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.cc
@@ -322,7 +322,7 @@ PipelineFuture<PipelineDescriptor> PipelineLibraryGLES::GetPipeline(
     FML_CHECK(result);
   };
 
-  if (async) {
+  if (async && compile_queue_) {
     compile_queue_->PostJobForDescriptor(descriptor,
                                          std::move(generation_task));
   } else {

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.cc
@@ -20,7 +20,11 @@ PipelineLibraryGLES::PipelineLibraryGLES(
     std::shared_ptr<ReactorGLES> reactor,
     fml::RefPtr<fml::TaskRunner> io_task_runner)
     : reactor_(std::move(reactor)),
-      io_task_runner_(std::move(io_task_runner)) {}
+      io_task_runner_(std::move(io_task_runner)),
+      compile_queue_(
+          PipelineCompileQueue::Create(std::shared_ptr<fml::BasicTaskRunner>(
+              io_task_runner_.get(),
+              [runner = io_task_runner_](fml::BasicTaskRunner*) {}))) {}
 
 static std::string GetShaderInfoLog(const ProcTableGLES& gl, GLuint shader) {
   GLint log_length = 0;
@@ -374,6 +378,10 @@ void PipelineLibraryGLES::SetProgramForKey(
     std::shared_ptr<UniqueHandleGLES> program) {
   Lock lock(programs_mutex_);
   programs_[key] = std::move(program);
+}
+
+PipelineCompileQueue* PipelineLibraryGLES::GetPipelineCompileQueue() const {
+  return compile_queue_.get();
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.cc
@@ -21,10 +21,7 @@ PipelineLibraryGLES::PipelineLibraryGLES(
     fml::RefPtr<fml::TaskRunner> io_task_runner)
     : reactor_(std::move(reactor)),
       io_task_runner_(std::move(io_task_runner)),
-      compile_queue_(
-          PipelineCompileQueue::Create(std::shared_ptr<fml::BasicTaskRunner>(
-              io_task_runner_.get(),
-              [runner = io_task_runner_](fml::BasicTaskRunner*) {}))) {}
+      compile_queue_(PipelineCompileQueueGLES::Create(io_task_runner_)) {}
 
 static std::string GetShaderInfoLog(const ProcTableGLES& gl, GLuint shader) {
   GLint log_length = 0;

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.cc
@@ -20,8 +20,7 @@ PipelineLibraryGLES::PipelineLibraryGLES(
     std::shared_ptr<ReactorGLES> reactor,
     fml::RefPtr<fml::TaskRunner> io_task_runner)
     : reactor_(std::move(reactor)),
-      io_task_runner_(std::move(io_task_runner)),
-      compile_queue_(PipelineCompileQueueGLES::Create(io_task_runner_)) {}
+      compile_queue_(PipelineCompileQueueGLES::Create(std::move(io_task_runner))) {}
 
 static std::string GetShaderInfoLog(const ProcTableGLES& gl, GLuint shader) {
   GLint log_length = 0;

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.h
@@ -93,7 +93,6 @@ class PipelineLibraryGLES final
   PipelineMap pipelines_;
   Mutex programs_mutex_;
   ProgramMap programs_ IPLR_GUARDED_BY(programs_mutex_);
-  fml::RefPtr<fml::TaskRunner> io_task_runner_;
   std::shared_ptr<PipelineCompileQueueGLES> compile_queue_;
 
   explicit PipelineLibraryGLES(std::shared_ptr<ReactorGLES> reactor,

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.h
@@ -11,6 +11,7 @@
 #include "flutter/fml/hash_combine.h"
 #include "flutter/fml/task_runner.h"
 #include "impeller/base/thread.h"
+#include "impeller/renderer/backend/gles/pipeline_compile_queue_gles.h"
 #include "impeller/renderer/backend/gles/reactor_gles.h"
 #include "impeller/renderer/backend/gles/unique_handle_gles.h"
 #include "impeller/renderer/pipeline_library.h"
@@ -93,7 +94,7 @@ class PipelineLibraryGLES final
   Mutex programs_mutex_;
   ProgramMap programs_ IPLR_GUARDED_BY(programs_mutex_);
   fml::RefPtr<fml::TaskRunner> io_task_runner_;
-  std::shared_ptr<PipelineCompileQueue> compile_queue_;
+  std::shared_ptr<PipelineCompileQueueGLES> compile_queue_;
 
   explicit PipelineLibraryGLES(std::shared_ptr<ReactorGLES> reactor,
                                fml::RefPtr<fml::TaskRunner> io_task_runner);

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "flutter/fml/hash_combine.h"
+#include "flutter/fml/task_runner.h"
 #include "impeller/base/thread.h"
 #include "impeller/renderer/backend/gles/reactor_gles.h"
 #include "impeller/renderer/backend/gles/unique_handle_gles.h"
@@ -91,8 +92,10 @@ class PipelineLibraryGLES final
   PipelineMap pipelines_;
   Mutex programs_mutex_;
   ProgramMap programs_ IPLR_GUARDED_BY(programs_mutex_);
+  fml::RefPtr<fml::TaskRunner> io_task_runner_;
 
-  explicit PipelineLibraryGLES(std::shared_ptr<ReactorGLES> reactor);
+  explicit PipelineLibraryGLES(std::shared_ptr<ReactorGLES> reactor,
+                               fml::RefPtr<fml::TaskRunner> io_task_runner);
 
   // |PipelineLibrary|
   bool IsValid() const override;

--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_library_gles.h
@@ -93,6 +93,7 @@ class PipelineLibraryGLES final
   Mutex programs_mutex_;
   ProgramMap programs_ IPLR_GUARDED_BY(programs_mutex_);
   fml::RefPtr<fml::TaskRunner> io_task_runner_;
+  std::shared_ptr<PipelineCompileQueue> compile_queue_;
 
   explicit PipelineLibraryGLES(std::shared_ptr<ReactorGLES> reactor,
                                fml::RefPtr<fml::TaskRunner> io_task_runner);
@@ -130,6 +131,8 @@ class PipelineLibraryGLES final
 
   void SetProgramForKey(const ProgramKey& key,
                         std::shared_ptr<UniqueHandleGLES> program);
+  // |PipelineLibrary|
+  PipelineCompileQueue* GetPipelineCompileQueue() const override;
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/pipeline_compile_queue_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/pipeline_compile_queue_gles_unittests.cc
@@ -1,0 +1,151 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/backend/gles/pipeline_compile_queue_gles.h"
+
+#include <atomic>
+#include <memory>
+#include <vector>
+
+#include "flutter/fml/synchronization/count_down_latch.h"
+#include "flutter/fml/task_runner.h"
+#include "flutter/fml/thread.h"
+#include "flutter/testing/testing.h"
+#include "impeller/renderer/pipeline_descriptor.h"
+
+namespace impeller {
+namespace testing {
+
+TEST(PipelineCompileQueueGLESTest, CreateReturnsNullWithNullTaskRunner) {
+  auto queue = PipelineCompileQueueGLES::Create(nullptr);
+  EXPECT_EQ(queue, nullptr);
+}
+
+TEST(PipelineCompileQueueGLESTest, CreateSucceedsWithValidTaskRunner) {
+  fml::Thread thread;
+  auto queue = PipelineCompileQueueGLES::Create(thread.GetTaskRunner());
+  EXPECT_NE(queue, nullptr);
+  thread.Join();
+}
+
+TEST(PipelineCompileQueueGLESTest, PostJobDoesNothingWithNullClosure) {
+  fml::Thread thread;
+  auto queue = PipelineCompileQueueGLES::Create(thread.GetTaskRunner());
+  ASSERT_NE(queue, nullptr);
+  queue->PostJob(nullptr);
+  thread.Join();
+}
+
+TEST(PipelineCompileQueueGLESTest, OnJobAddedProcessesJobsSequentially) {
+  fml::Thread thread;
+  auto queue = PipelineCompileQueueGLES::Create(thread.GetTaskRunner());
+  ASSERT_NE(queue, nullptr);
+
+  std::atomic<int> execution_order{0};
+  std::vector<int> results;
+  std::mutex results_mutex;
+  fml::CountDownLatch latch(3);
+
+  PipelineDescriptor desc1;
+  desc1.SetSampleCount(SampleCount::kCount1);
+  desc1.SetCullMode(CullMode::kNone);
+
+  PipelineDescriptor desc2;
+  desc2.SetSampleCount(SampleCount::kCount1);
+  desc2.SetCullMode(CullMode::kFrontFace);
+
+  PipelineDescriptor desc3;
+  desc3.SetSampleCount(SampleCount::kCount1);
+  desc3.SetCullMode(CullMode::kBackFace);
+
+  queue->PostJobForDescriptor(desc1, [&]() {
+    {
+      std::lock_guard<std::mutex> lock(results_mutex);
+      results.push_back(1);
+    }
+    execution_order = 1;
+    latch.CountDown();
+  });
+
+  queue->PostJobForDescriptor(desc2, [&]() {
+    {
+      std::lock_guard<std::mutex> lock(results_mutex);
+      results.push_back(2);
+    }
+    execution_order = 2;
+    latch.CountDown();
+  });
+
+  queue->PostJobForDescriptor(desc3, [&]() {
+    {
+      std::lock_guard<std::mutex> lock(results_mutex);
+      results.push_back(3);
+    }
+    execution_order = 3;
+    latch.CountDown();
+  });
+
+  latch.Wait();
+
+  EXPECT_EQ(results.size(), 3u);
+  std::sort(results.begin(), results.end());
+  EXPECT_EQ(results[0], 1);
+  EXPECT_EQ(results[1], 2);
+  EXPECT_EQ(results[2], 3);
+  thread.Join();
+}
+
+TEST(PipelineCompileQueueGLESTest,
+     PostJobForDescriptorWithDuplicateRunsEagerly) {
+  fml::Thread thread;
+  auto queue = PipelineCompileQueueGLES::Create(thread.GetTaskRunner());
+  ASSERT_NE(queue, nullptr);
+
+  std::atomic<int> first_job_count{0};
+  std::atomic<int> second_job_count{0};
+  fml::CountDownLatch latch(2);
+
+  PipelineDescriptor desc;
+
+  queue->PostJobForDescriptor(desc, [&]() {
+    first_job_count++;
+    latch.CountDown();
+  });
+
+  queue->PostJobForDescriptor(desc, [&]() {
+    second_job_count++;
+    latch.CountDown();
+  });
+
+  latch.Wait();
+
+  EXPECT_EQ(first_job_count, 1);
+  EXPECT_EQ(second_job_count, 1);
+  thread.Join();
+}
+
+TEST(PipelineCompileQueueGLESTest, IsProcessingResetsAfterAllJobsComplete) {
+  fml::Thread thread;
+  auto queue = PipelineCompileQueueGLES::Create(thread.GetTaskRunner());
+  ASSERT_NE(queue, nullptr);
+
+  fml::CountDownLatch latch(1);
+
+  queue->PostJobForDescriptor(PipelineDescriptor{},
+                              [&]() { latch.CountDown(); });
+
+  latch.Wait();
+
+  fml::CountDownLatch latch2(1);
+  queue->PostJobForDescriptor(PipelineDescriptor{},
+                              [&]() { latch2.CountDown(); });
+
+  latch2.Wait();
+
+  SUCCEED();
+  thread.Join();
+}
+
+}  // namespace testing
+}  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/pipeline_compile_queue_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/pipeline_compile_queue_gles_unittests.cc
@@ -42,9 +42,7 @@ TEST(PipelineCompileQueueGLESTest, OnJobAddedProcessesJobsSequentially) {
   auto queue = PipelineCompileQueueGLES::Create(thread.GetTaskRunner());
   ASSERT_NE(queue, nullptr);
 
-  std::atomic<int> execution_order{0};
-  std::vector<int> results;
-  std::mutex results_mutex;
+  std::atomic<int> completed_jobs{0};
   fml::CountDownLatch latch(3);
 
   PipelineDescriptor desc1;
@@ -60,39 +58,27 @@ TEST(PipelineCompileQueueGLESTest, OnJobAddedProcessesJobsSequentially) {
   desc3.SetCullMode(CullMode::kBackFace);
 
   queue->PostJobForDescriptor(desc1, [&]() {
-    {
-      std::lock_guard<std::mutex> lock(results_mutex);
-      results.push_back(1);
-    }
-    execution_order = 1;
+    std::this_thread::sleep_for(std::chrono::milliseconds(80));
+    completed_jobs++;
     latch.CountDown();
   });
 
   queue->PostJobForDescriptor(desc2, [&]() {
-    {
-      std::lock_guard<std::mutex> lock(results_mutex);
-      results.push_back(2);
-    }
-    execution_order = 2;
+    std::this_thread::sleep_for(std::chrono::milliseconds(80));
+    completed_jobs++;
     latch.CountDown();
   });
 
   queue->PostJobForDescriptor(desc3, [&]() {
-    {
-      std::lock_guard<std::mutex> lock(results_mutex);
-      results.push_back(3);
-    }
-    execution_order = 3;
+    std::this_thread::sleep_for(std::chrono::milliseconds(80));
+    completed_jobs++;
     latch.CountDown();
   });
 
   latch.Wait();
 
-  EXPECT_EQ(results.size(), 3u);
-  std::sort(results.begin(), results.end());
-  EXPECT_EQ(results[0], 1);
-  EXPECT_EQ(results[1], 2);
-  EXPECT_EQ(results[2], 3);
+  EXPECT_EQ(completed_jobs, 3);
+
   thread.Join();
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/pipeline_compile_queue_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/pipeline_compile_queue_gles_unittests.cc
@@ -133,5 +133,53 @@ TEST(PipelineCompileQueueGLESTest, IsProcessingResetsAfterAllJobsComplete) {
   thread.Join();
 }
 
+TEST(PipelineCompileQueueGLESTest, DestroyQueueWithPendingTasks) {
+  fml::Thread thread;
+  std::atomic<int> completed_jobs{0};
+  fml::CountDownLatch latch(3);
+
+  {
+    auto queue = PipelineCompileQueueGLES::Create(thread.GetTaskRunner());
+    ASSERT_NE(queue, nullptr);
+
+    PipelineDescriptor desc1;
+    desc1.SetSampleCount(SampleCount::kCount1);
+    desc1.SetCullMode(CullMode::kNone);
+
+    PipelineDescriptor desc2;
+    desc2.SetSampleCount(SampleCount::kCount1);
+    desc2.SetCullMode(CullMode::kFrontFace);
+
+    PipelineDescriptor desc3;
+    desc3.SetSampleCount(SampleCount::kCount1);
+    desc3.SetCullMode(CullMode::kBackFace);
+
+    queue->PostJobForDescriptor(desc1, [&]() {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      completed_jobs++;
+      latch.CountDown();
+    });
+
+    queue->PostJobForDescriptor(desc2, [&]() {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      completed_jobs++;
+      latch.CountDown();
+    });
+
+    queue->PostJobForDescriptor(desc3, [&]() {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      completed_jobs++;
+      latch.CountDown();
+    });
+
+    // Queue will be destroyed here with pending jobs.
+    // The destructor should block and wait for all jobs to complete.
+  }
+
+  // All jobs should be completed before the queue is destroyed.
+  EXPECT_EQ(completed_jobs, 3);
+  thread.Join();
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
@@ -80,6 +80,8 @@ impeller_component("vulkan") {
     "pipeline_cache_data_vk.h",
     "pipeline_cache_vk.cc",
     "pipeline_cache_vk.h",
+    "pipeline_compile_queue_vulkan.cc",
+    "pipeline_compile_queue_vulkan.h",
     "pipeline_library_vk.cc",
     "pipeline_library_vk.h",
     "pipeline_vk.cc",

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
@@ -28,6 +28,7 @@ impeller_component("vulkan_unittests") {
     "test/mock_vulkan.cc",
     "test/mock_vulkan.h",
     "test/mock_vulkan_unittests.cc",
+    "test/pipeline_compile_queue_vulkan_unittests.cc",
     "test/sampler_library_vk_unittests.cc",
     "test/swapchain_unittests.cc",
   ]

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.cc
@@ -20,7 +20,7 @@ PipelineCompileQueueVulkan::PipelineCompileQueueVulkan(
     : PipelineCompileQueue(),
       worker_task_runner_(std::move(worker_task_runner)) {}
 
-PipelineCompileQueueVulkan::~PipelineCompileQueueVulkan() {}
+PipelineCompileQueueVulkan::~PipelineCompileQueueVulkan() = default;
 
 void PipelineCompileQueueVulkan::OnJobAdded() {
   PostJob([weak_queue = weak_from_this()]() {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.cc
@@ -22,31 +22,13 @@ PipelineCompileQueueVulkan::PipelineCompileQueueVulkan(
 
 PipelineCompileQueueVulkan::~PipelineCompileQueueVulkan() {}
 
-bool PipelineCompileQueueVulkan::PostJobForDescriptor(
-    const PipelineDescriptor& desc,
-    const fml::closure& job) {
-  if (!job) {
-    return false;
-  }
-
-  if (!AddJob(desc, job)) {
-    // This bit is being extremely conservative. If insertion did not take
-    // place, someone gave the compile queue a job for the same description.
-    // This is highly unusual but technically not impossible. Just run the job
-    // eagerly.
-    FML_LOG(ERROR) << "Got multiple compile jobs for the same descriptor. "
-                      "Running eagerly.";
-    PostJob(job);
-    return true;
-  }
-
+void PipelineCompileQueueVulkan::OnJobAdded() {
   PostJob([weak_queue = weak_from_this()]() {
     if (auto queue = std::static_pointer_cast<PipelineCompileQueueVulkan>(
             weak_queue.lock())) {
       queue->DoOneJob();
     }
   });
-  return true;
 }
 
 void PipelineCompileQueueVulkan::PostJob(const fml::closure& job) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.cc
@@ -22,6 +22,32 @@ PipelineCompileQueueVulkan::PipelineCompileQueueVulkan(
 
 PipelineCompileQueueVulkan::~PipelineCompileQueueVulkan() {}
 
+bool PipelineCompileQueueVulkan::PostJobForDescriptor(
+    const PipelineDescriptor& desc,
+    const fml::closure& job) {
+  if (!job) {
+    return false;
+  }
+
+  if (!AddJob(desc, job)) {
+    // This bit is being extremely conservative. If insertion did not take
+    // place, someone gave the compile queue a job for the same description.
+    // This is highly unusual but technically not impossible. Just run the job
+    // eagerly.
+    FML_LOG(ERROR) << "Got multiple compile jobs for the same descriptor. "
+                      "Running eagerly.";
+    PostJob(job);
+    return true;
+  }
+
+  PostJob([weak_queue = weak_from_this()]() {
+    if (auto queue = weak_queue.lock()) {
+      queue->DoOneJob();
+    }
+  });
+  return true;
+}
+
 void PipelineCompileQueueVulkan::PostJob(const fml::closure& job) {
   if (!job) {
     return;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.cc
@@ -1,0 +1,33 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.h"
+
+#include "flutter/fml/logging.h"
+#include "flutter/fml/trace_event.h"
+
+namespace impeller {
+
+std::shared_ptr<PipelineCompileQueueVulkan> PipelineCompileQueueVulkan::Create(
+    std::shared_ptr<fml::BasicTaskRunner> worker_task_runner) {
+  return std::shared_ptr<PipelineCompileQueueVulkan>(
+      new PipelineCompileQueueVulkan(std::move(worker_task_runner)));
+}
+
+PipelineCompileQueueVulkan::PipelineCompileQueueVulkan(
+    std::shared_ptr<fml::BasicTaskRunner> worker_task_runner)
+    : PipelineCompileQueue(),
+      worker_task_runner_(std::move(worker_task_runner)) {}
+
+PipelineCompileQueueVulkan::~PipelineCompileQueueVulkan() {}
+
+void PipelineCompileQueueVulkan::PostJob(const fml::closure& job) {
+  if (!job) {
+    return;
+  }
+
+  worker_task_runner_->PostTask(job);
+}
+
+}  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.cc
@@ -11,6 +11,9 @@ namespace impeller {
 
 std::shared_ptr<PipelineCompileQueueVulkan> PipelineCompileQueueVulkan::Create(
     std::shared_ptr<fml::BasicTaskRunner> worker_task_runner) {
+  if (!worker_task_runner) {
+    return nullptr;
+  }
   return std::shared_ptr<PipelineCompileQueueVulkan>(
       new PipelineCompileQueueVulkan(std::move(worker_task_runner)));
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.cc
@@ -41,7 +41,8 @@ bool PipelineCompileQueueVulkan::PostJobForDescriptor(
   }
 
   PostJob([weak_queue = weak_from_this()]() {
-    if (auto queue = weak_queue.lock()) {
+    if (auto queue = std::static_pointer_cast<PipelineCompileQueueVulkan>(
+            weak_queue.lock())) {
       queue->DoOneJob();
     }
   });

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.h
@@ -16,9 +16,6 @@ class PipelineCompileQueueVulkan : public PipelineCompileQueue {
   static std::shared_ptr<PipelineCompileQueueVulkan> Create(
       std::shared_ptr<fml::BasicTaskRunner> worker_task_runner);
 
-  explicit PipelineCompileQueueVulkan(
-      std::shared_ptr<fml::BasicTaskRunner> worker_task_runner);
-
   ~PipelineCompileQueueVulkan() override;
 
   PipelineCompileQueueVulkan(const PipelineCompileQueueVulkan&) = delete;
@@ -31,6 +28,8 @@ class PipelineCompileQueueVulkan : public PipelineCompileQueue {
   void OnJobAdded() override;
 
  private:
+  explicit PipelineCompileQueueVulkan(
+      std::shared_ptr<fml::BasicTaskRunner> worker_task_runner);
   std::shared_ptr<fml::BasicTaskRunner> worker_task_runner_;
 };
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.h
@@ -27,23 +27,17 @@ class PipelineCompileQueueVulkan : public PipelineCompileQueue {
       delete;
 
   //----------------------------------------------------------------------------
-  /// @brief      Post a compile job for the specified descriptor.
-  ///
-  /// @param[in]  desc  The description
-  /// @param[in]  job   The job
-  ///
-  /// @return     If the job was successfully posted to the parallel task
-  /// runners.
-  ///
-  bool PostJobForDescriptor(const PipelineDescriptor& desc,
-                            const fml::closure& job) override;
-
-  //----------------------------------------------------------------------------
   /// @brief      Post a job to the worker task runner.
   ///
   /// @param[in]  job   The job
   ///
   void PostJob(const fml::closure& job) override;
+
+  //----------------------------------------------------------------------------
+  /// @brief      Called after a job has been added to the queue. Implements
+  ///             the parallel scheduling strategy for Vulkan.
+  ///
+  void OnJobAdded() override;
 
  private:
   std::shared_ptr<fml::BasicTaskRunner> worker_task_runner_;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.h
@@ -26,17 +26,8 @@ class PipelineCompileQueueVulkan : public PipelineCompileQueue {
   PipelineCompileQueueVulkan& operator=(const PipelineCompileQueueVulkan&) =
       delete;
 
-  //----------------------------------------------------------------------------
-  /// @brief      Post a job to the worker task runner.
-  ///
-  /// @param[in]  job   The job
-  ///
   void PostJob(const fml::closure& job) override;
 
-  //----------------------------------------------------------------------------
-  /// @brief      Called after a job has been added to the queue. Implements
-  ///             the parallel scheduling strategy for Vulkan.
-  ///
   void OnJobAdded() override;
 
  private:

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.h
@@ -11,6 +11,24 @@
 
 namespace impeller {
 
+//------------------------------------------------------------------------------
+/// @brief      A task queue designed for managing compilation of pipeline state
+///             objects for Vulkan backend.
+///
+///             This subclass uses a fml::BasicTaskRunner as the worker task
+///             runner and dispatches compile jobs directly without sequential
+///             processing constraints.
+///
+///             Key characteristics:
+///             - Uses std::shared_ptr<fml::BasicTaskRunner> for
+///             worker_task_runner_
+///             - Dispatches jobs directly to the task runner in OnJobAdded()
+///             - Does not implement sequential processing like GLES version
+///
+///             The Vulkan backend benefits from the parallel nature of pipeline
+///             compilation, allowing multiple compile jobs to be processed
+///             concurrently through the task runner.
+///
 class PipelineCompileQueueVulkan : public PipelineCompileQueue {
  public:
   static std::shared_ptr<PipelineCompileQueueVulkan> Create(

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.h
@@ -27,6 +27,18 @@ class PipelineCompileQueueVulkan : public PipelineCompileQueue {
       delete;
 
   //----------------------------------------------------------------------------
+  /// @brief      Post a compile job for the specified descriptor.
+  ///
+  /// @param[in]  desc  The description
+  /// @param[in]  job   The job
+  ///
+  /// @return     If the job was successfully posted to the parallel task
+  /// runners.
+  ///
+  bool PostJobForDescriptor(const PipelineDescriptor& desc,
+                            const fml::closure& job) override;
+
+  //----------------------------------------------------------------------------
   /// @brief      Post a job to the worker task runner.
   ///
   /// @param[in]  job   The job

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.h
@@ -1,0 +1,42 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_PIPELINE_COMPILE_QUEUE_VULKAN_H_
+#define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_PIPELINE_COMPILE_QUEUE_VULKAN_H_
+
+#include "flutter/fml/closure.h"
+#include "flutter/fml/task_runner.h"
+#include "impeller/renderer/pipeline_compile_queue.h"
+
+namespace impeller {
+
+class PipelineCompileQueueVulkan : public PipelineCompileQueue {
+ public:
+  static std::shared_ptr<PipelineCompileQueueVulkan> Create(
+      std::shared_ptr<fml::BasicTaskRunner> worker_task_runner);
+
+  explicit PipelineCompileQueueVulkan(
+      std::shared_ptr<fml::BasicTaskRunner> worker_task_runner);
+
+  ~PipelineCompileQueueVulkan() override;
+
+  PipelineCompileQueueVulkan(const PipelineCompileQueueVulkan&) = delete;
+
+  PipelineCompileQueueVulkan& operator=(const PipelineCompileQueueVulkan&) =
+      delete;
+
+  //----------------------------------------------------------------------------
+  /// @brief      Post a job to the worker task runner.
+  ///
+  /// @param[in]  job   The job
+  ///
+  void PostJob(const fml::closure& job) override;
+
+ private:
+  std::shared_ptr<fml::BasicTaskRunner> worker_task_runner_;
+};
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_PIPELINE_COMPILE_QUEUE_VULKAN_H_

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_library_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_library_vk.cc
@@ -27,7 +27,7 @@ PipelineLibraryVK::PipelineLibraryVK(
                                                    device_holder,
                                                    std::move(cache_directory))),
       worker_task_runner_(std::move(worker_task_runner)),
-      compile_queue_(PipelineCompileQueueVulkan::Create(worker_task_runner)) {
+      compile_queue_(PipelineCompileQueueVulkan::Create(worker_task_runner_)) {
   FML_DCHECK(worker_task_runner_);
   if (!pso_cache_->IsValid() || !worker_task_runner_) {
     return;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_library_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_library_vk.cc
@@ -27,7 +27,7 @@ PipelineLibraryVK::PipelineLibraryVK(
                                                    device_holder,
                                                    std::move(cache_directory))),
       worker_task_runner_(std::move(worker_task_runner)),
-      compile_queue_(PipelineCompileQueue::Create(worker_task_runner_)) {
+      compile_queue_(PipelineCompileQueueVulkan::Create(worker_task_runner)) {
   FML_DCHECK(worker_task_runner_);
   if (!pso_cache_->IsValid() || !worker_task_runner_) {
     return;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_library_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_library_vk.h
@@ -13,10 +13,10 @@
 #include "impeller/base/thread.h"
 #include "impeller/renderer/backend/vulkan/compute_pipeline_vk.h"
 #include "impeller/renderer/backend/vulkan/pipeline_cache_vk.h"
+#include "impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.h"
 #include "impeller/renderer/backend/vulkan/pipeline_vk.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
 #include "impeller/renderer/pipeline.h"
-#include "impeller/renderer/pipeline_compile_queue.h"
 #include "impeller/renderer/pipeline_library.h"
 
 namespace impeller {
@@ -49,7 +49,7 @@ class PipelineLibraryVK final
   PipelineKey pipeline_key_ IPLR_GUARDED_BY(pipelines_mutex_) = 1;
   bool is_valid_ = false;
   bool cache_dirty_ = false;
-  std::shared_ptr<PipelineCompileQueue> compile_queue_;
+  std::shared_ptr<PipelineCompileQueueVulkan> compile_queue_;
 
   PipelineLibraryVK(
       const std::shared_ptr<DeviceHolderVK>& device_holder,

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/pipeline_compile_queue_vulkan_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/pipeline_compile_queue_vulkan_unittests.cc
@@ -1,0 +1,181 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/backend/vulkan/pipeline_compile_queue_vulkan.h"
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "flutter/fml/synchronization/count_down_latch.h"
+#include "flutter/fml/task_runner.h"
+#include "flutter/testing/testing.h"
+#include "impeller/renderer/pipeline_descriptor.h"
+
+namespace impeller {
+namespace testing {
+
+TEST(PipelineCompileQueueVulkanTest, CreateSucceedsWithValidTaskRunner) {
+  auto loop = fml::ConcurrentMessageLoop::Create();
+  auto queue = PipelineCompileQueueVulkan::Create(loop->GetTaskRunner());
+  EXPECT_NE(queue, nullptr);
+}
+
+TEST(PipelineCompileQueueVulkanTest, PostJobDoesNothingWithNullClosure) {
+  auto loop = fml::ConcurrentMessageLoop::Create();
+  auto queue = PipelineCompileQueueVulkan::Create(loop->GetTaskRunner());
+  ASSERT_NE(queue, nullptr);
+
+  queue->PostJob(nullptr);
+}
+
+TEST(PipelineCompileQueueVulkanTest, OnJobAddedProcessesJobsInParallel) {
+  auto loop = fml::ConcurrentMessageLoop::Create();
+  auto queue = PipelineCompileQueueVulkan::Create(loop->GetTaskRunner());
+  ASSERT_NE(queue, nullptr);
+
+  std::atomic<int> concurrent_jobs{0};
+  std::atomic<int> max_concurrent{0};
+  fml::CountDownLatch latch(3);
+
+  PipelineDescriptor desc1;
+  desc1.SetSampleCount(SampleCount::kCount1);
+  desc1.SetCullMode(CullMode::kNone);
+
+  PipelineDescriptor desc2;
+  desc2.SetSampleCount(SampleCount::kCount1);
+  desc2.SetCullMode(CullMode::kFrontFace);
+
+  PipelineDescriptor desc3;
+  desc3.SetSampleCount(SampleCount::kCount1);
+  desc3.SetCullMode(CullMode::kBackFace);
+
+  queue->PostJobForDescriptor(desc1, [&]() {
+    int current = ++concurrent_jobs;
+    int prev_max = max_concurrent.load();
+    while (current > prev_max &&
+           !max_concurrent.compare_exchange_weak(prev_max, current)) {
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    concurrent_jobs--;
+    latch.CountDown();
+  });
+
+  queue->PostJobForDescriptor(desc2, [&]() {
+    int current = ++concurrent_jobs;
+    int prev_max = max_concurrent.load();
+    while (current > prev_max &&
+           !max_concurrent.compare_exchange_weak(prev_max, current)) {
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    concurrent_jobs--;
+    latch.CountDown();
+  });
+
+  queue->PostJobForDescriptor(desc3, [&]() {
+    int current = ++concurrent_jobs;
+    int prev_max = max_concurrent.load();
+    while (current > prev_max &&
+           !max_concurrent.compare_exchange_weak(prev_max, current)) {
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    concurrent_jobs--;
+    latch.CountDown();
+  });
+
+  latch.Wait();
+
+  EXPECT_GE(max_concurrent.load(), 1);
+}
+
+TEST(PipelineCompileQueueVulkanTest,
+     PostJobForDescriptorWithDuplicateRunsEagerly) {
+  auto loop = fml::ConcurrentMessageLoop::Create();
+  auto queue = PipelineCompileQueueVulkan::Create(loop->GetTaskRunner());
+  ASSERT_NE(queue, nullptr);
+
+  std::atomic<int> first_job_count{0};
+  std::atomic<int> second_job_count{0};
+  fml::CountDownLatch latch(2);
+
+  PipelineDescriptor desc;
+
+  queue->PostJobForDescriptor(desc, [&]() {
+    first_job_count++;
+    latch.CountDown();
+  });
+
+  queue->PostJobForDescriptor(desc, [&]() {
+    second_job_count++;
+    latch.CountDown();
+  });
+
+  latch.Wait();
+
+  EXPECT_EQ(first_job_count, 1);
+  EXPECT_EQ(second_job_count, 1);
+}
+
+TEST(PipelineCompileQueueVulkanTest, MultipleJobsCompleteSuccessfully) {
+  auto loop = fml::ConcurrentMessageLoop::Create();
+  auto queue = PipelineCompileQueueVulkan::Create(loop->GetTaskRunner());
+  ASSERT_NE(queue, nullptr);
+
+  std::atomic<int> completed_jobs{0};
+  fml::CountDownLatch latch(5);
+
+  PipelineDescriptor desc1;
+  desc1.SetSampleCount(SampleCount::kCount1);
+  desc1.SetCullMode(CullMode::kNone);
+
+  PipelineDescriptor desc2;
+  desc2.SetSampleCount(SampleCount::kCount1);
+  desc2.SetCullMode(CullMode::kFrontFace);
+
+  PipelineDescriptor desc3;
+  desc3.SetSampleCount(SampleCount::kCount1);
+  desc3.SetCullMode(CullMode::kBackFace);
+
+  PipelineDescriptor desc4;
+  desc4.SetSampleCount(SampleCount::kCount4);
+  desc4.SetCullMode(CullMode::kNone);
+
+  PipelineDescriptor desc5;
+  desc5.SetSampleCount(SampleCount::kCount4);
+  desc5.SetCullMode(CullMode::kFrontFace);
+
+  // Post 5 jobs with distinct descriptors
+  queue->PostJobForDescriptor(desc1, [&]() {
+    completed_jobs++;
+    latch.CountDown();
+  });
+
+  queue->PostJobForDescriptor(desc2, [&]() {
+    completed_jobs++;
+    latch.CountDown();
+  });
+
+  queue->PostJobForDescriptor(desc3, [&]() {
+    completed_jobs++;
+    latch.CountDown();
+  });
+
+  queue->PostJobForDescriptor(desc4, [&]() {
+    completed_jobs++;
+    latch.CountDown();
+  });
+
+  queue->PostJobForDescriptor(desc5, [&]() {
+    completed_jobs++;
+    latch.CountDown();
+  });
+
+  latch.Wait();
+
+  EXPECT_EQ(completed_jobs, 5);
+}
+
+}  // namespace testing
+}  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
@@ -9,6 +9,9 @@
 
 namespace impeller {
 
+PipelineCompileQueue::PipelineCompileQueue(bool wait_until_rendering)
+    : wait_until_rendering_(wait_until_rendering) {}
+
 PipelineCompileQueue::~PipelineCompileQueue() {
   FinishAllJobs();
 }
@@ -35,12 +38,13 @@ bool PipelineCompileQueue::PostJobForDescriptor(const PipelineDescriptor& desc,
       return true;
     }
   }
-
-  PostJob([weak_queue = weak_from_this()]() {
-    if (auto queue = weak_queue.lock()) {
-      queue->DoOneJob();
-    }
-  });
+  if (!WaitUntilRendering()) {
+    PostJob([weak_queue = weak_from_this()]() {
+      if (auto queue = weak_queue.lock()) {
+        queue->DoOneJob();
+      }
+    });
+  }
   return true;
 }
 
@@ -80,6 +84,14 @@ void PipelineCompileQueue::DoOneJob() {
   if (auto job = TakeNextJob()) {
     job();
   }
+}
+
+void PipelineCompileQueue::FlushPendingJobs() {
+  PostJob([weak_queue = weak_from_this()]() {
+    if (auto queue = weak_queue.lock()) {
+      queue->FinishAllJobs();
+    }
+  });
 }
 
 void PipelineCompileQueue::FinishAllJobs() {

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
@@ -41,12 +41,12 @@ bool PipelineCompileQueue::PostJobForDescriptor(const PipelineDescriptor& desc,
                         "Running eagerly.";
       // Don't invoke the job here has there are we have currently acquired a
       // mutex.
-      worker_task_runner_->PostTask(job);
+      PostJob(job);
       return true;
     }
   }
 
-  worker_task_runner_->PostTask([weak_queue = weak_from_this()]() {
+  PostJob([weak_queue = weak_from_this()]() {
     if (auto queue = weak_queue.lock()) {
       queue->DoOneJob();
     }
@@ -113,6 +113,14 @@ void PipelineCompileQueue::PerformJobEagerly(const PipelineDescriptor& desc) {
   if (auto job = TakeJob(desc)) {
     job();
   }
+}
+
+void PipelineCompileQueue::PostJob(const fml::closure& job) {
+  if (!job) {
+    return;
+  }
+
+  worker_task_runner_->PostTask(job);
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
@@ -88,11 +88,24 @@ void PipelineCompileQueue::DoOneJob() {
 
 void PipelineCompileQueue::FlushPendingJobs() {
   wait_until_rendering_ = false;
+  ProcessJobsSequentially();
+}
+
+void PipelineCompileQueue::ProcessJobsSequentially() {
   PostJob([weak_queue = weak_from_this()]() {
     if (auto queue = weak_queue.lock()) {
-      queue->FinishAllJobs();
+      queue->DoOneJob();
+      if (!queue->HasPendingJobs()) {
+        return;
+      }
+      queue->ProcessJobsSequentially();
     }
   });
+}
+
+bool PipelineCompileQueue::HasPendingJobs() {
+  Lock lock(pending_jobs_mutex_);
+  return !pending_jobs_.empty();
 }
 
 void PipelineCompileQueue::FinishAllJobs() {

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
@@ -9,43 +9,20 @@
 
 namespace impeller {
 
-PipelineCompileQueue::PipelineCompileQueue(bool wait_until_rendering)
-    : wait_until_rendering_(wait_until_rendering) {}
-
 PipelineCompileQueue::~PipelineCompileQueue() {
   FinishAllJobs();
 }
 
-bool PipelineCompileQueue::PostJobForDescriptor(const PipelineDescriptor& desc,
-                                                const fml::closure& job) {
-  if (!job) {
-    return false;
-  }
+bool PipelineCompileQueue::AddJob(const PipelineDescriptor& desc,
+                                  const fml::closure& job) {
+  Lock lock(pending_jobs_mutex_);
+  auto insertion_result = pending_jobs_.insert(std::make_pair(desc, job));
+  return insertion_result.second;
+}
 
-  {
-    Lock lock(pending_jobs_mutex_);
-    auto insertion_result = pending_jobs_.insert(std::make_pair(desc, job));
-    if (!insertion_result.second) {
-      // This bit is being extremely conservative. If insertion did not take
-      // place, someone gave the compile queue a job for the same description.
-      // This is highly unusual but technically not impossible. Just run the job
-      // eagerly.
-      FML_LOG(ERROR) << "Got multiple compile jobs for the same descriptor. "
-                        "Running eagerly.";
-      // Don't invoke the job here has there are we have currently acquired a
-      // mutex.
-      PostJob(job);
-      return true;
-    }
-  }
-  if (!WaitUntilRendering()) {
-    PostJob([weak_queue = weak_from_this()]() {
-      if (auto queue = weak_queue.lock()) {
-        queue->DoOneJob();
-      }
-    });
-  }
-  return true;
+bool PipelineCompileQueue::HasPendingJobs() {
+  Lock lock(pending_jobs_mutex_);
+  return !pending_jobs_.empty();
 }
 
 fml::closure PipelineCompileQueue::TakeNextJob() {
@@ -84,28 +61,6 @@ void PipelineCompileQueue::DoOneJob() {
   if (auto job = TakeNextJob()) {
     job();
   }
-}
-
-void PipelineCompileQueue::FlushPendingJobs() {
-  wait_until_rendering_ = false;
-  ProcessJobsSequentially();
-}
-
-void PipelineCompileQueue::ProcessJobsSequentially() {
-  PostJob([weak_queue = weak_from_this()]() {
-    if (auto queue = weak_queue.lock()) {
-      queue->DoOneJob();
-      if (!queue->HasPendingJobs()) {
-        return;
-      }
-      queue->ProcessJobsSequentially();
-    }
-  });
-}
-
-bool PipelineCompileQueue::HasPendingJobs() {
-  Lock lock(pending_jobs_mutex_);
-  return !pending_jobs_.empty();
 }
 
 void PipelineCompileQueue::FinishAllJobs() {

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
@@ -10,13 +10,13 @@
 namespace impeller {
 
 std::shared_ptr<PipelineCompileQueue> PipelineCompileQueue::Create(
-    std::shared_ptr<fml::ConcurrentTaskRunner> worker_task_runner) {
+    std::shared_ptr<fml::BasicTaskRunner> worker_task_runner) {
   return std::shared_ptr<PipelineCompileQueue>(
       new PipelineCompileQueue(std::move(worker_task_runner)));
 }
 
 PipelineCompileQueue::PipelineCompileQueue(
-    std::shared_ptr<fml::ConcurrentTaskRunner> worker_task_runner)
+    std::shared_ptr<fml::BasicTaskRunner> worker_task_runner)
     : worker_task_runner_(std::move(worker_task_runner)) {}
 
 PipelineCompileQueue::~PipelineCompileQueue() {

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
@@ -13,6 +13,27 @@ PipelineCompileQueue::~PipelineCompileQueue() {
   FinishAllJobs();
 }
 
+bool PipelineCompileQueue::PostJobForDescriptor(const PipelineDescriptor& desc,
+                                                const fml::closure& job) {
+  if (!job) {
+    return false;
+  }
+
+  if (!AddJob(desc, job)) {
+    // This bit is being extremely conservative. If insertion did not take
+    // place, someone gave the compile queue a job for the same description.
+    // This is highly unusual but technically not impossible. Just run the job
+    // eagerly.
+    FML_LOG(ERROR) << "Got multiple compile jobs for the same descriptor. "
+                      "Running eagerly.";
+    PostJob(job);
+    return true;
+  }
+
+  OnJobAdded();
+  return true;
+}
+
 bool PipelineCompileQueue::AddJob(const PipelineDescriptor& desc,
                                   const fml::closure& job) {
   Lock lock(pending_jobs_mutex_);

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
@@ -24,8 +24,8 @@ bool PipelineCompileQueue::PostJobForDescriptor(const PipelineDescriptor& desc,
     // place, someone gave the compile queue a job for the same description.
     // This is highly unusual but technically not impossible. Just run the job
     // eagerly.
-    FML_LOG(ERROR) << "Got multiple compile jobs for the same descriptor. "
-                      "Running eagerly.";
+    FML_LOG(WARNING) << "Got multiple compile jobs for the same descriptor. "
+                        "Running eagerly.";
     PostJob(job);
     return true;
   }

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
@@ -9,16 +9,6 @@
 
 namespace impeller {
 
-std::shared_ptr<PipelineCompileQueue> PipelineCompileQueue::Create(
-    std::shared_ptr<fml::BasicTaskRunner> worker_task_runner) {
-  return std::shared_ptr<PipelineCompileQueue>(
-      new PipelineCompileQueue(std::move(worker_task_runner)));
-}
-
-PipelineCompileQueue::PipelineCompileQueue(
-    std::shared_ptr<fml::BasicTaskRunner> worker_task_runner)
-    : worker_task_runner_(std::move(worker_task_runner)) {}
-
 PipelineCompileQueue::~PipelineCompileQueue() {
   FinishAllJobs();
 }
@@ -113,14 +103,6 @@ void PipelineCompileQueue::PerformJobEagerly(const PipelineDescriptor& desc) {
   if (auto job = TakeJob(desc)) {
     job();
   }
-}
-
-void PipelineCompileQueue::PostJob(const fml::closure& job) {
-  if (!job) {
-    return;
-  }
-
-  worker_task_runner_->PostTask(job);
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
@@ -87,6 +87,7 @@ void PipelineCompileQueue::DoOneJob() {
 }
 
 void PipelineCompileQueue::FlushPendingJobs() {
+  wait_until_rendering_ = false;
   PostJob([weak_queue = weak_from_this()]() {
     if (auto queue = weak_queue.lock()) {
       queue->FinishAllJobs();

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
@@ -72,6 +72,15 @@ class PipelineCompileQueue
   void PerformJobEagerly(const PipelineDescriptor& desc);
 
  protected:
+  //----------------------------------------------------------------------------
+  /// @brief      Post a compilation job to the worker task runner.
+  ///
+  ///             This is a pure virtual function that must be implemented by
+  ///             subclasses. It is responsible for actually dispatching the
+  ///             job closure to the appropriate task runner for execution.
+  ///
+  /// @param[in]  job  The compilation job closure to post
+  ///
   virtual void PostJob(const fml::closure& job) = 0;
 
   //----------------------------------------------------------------------------
@@ -85,8 +94,33 @@ class PipelineCompileQueue
   ///
   virtual void OnJobAdded() = 0;
 
+  //----------------------------------------------------------------------------
+  /// @brief      Execute one pending compilation job from the queue.
+  ///
+  ///             This method retrieves and executes a single job from the
+  ///             pending jobs queue. It is typically called by subclasses
+  ///             when they are ready to process the next job in the queue.
+  ///
   void DoOneJob();
+
+  //----------------------------------------------------------------------------
+  /// @brief      Add a compilation job to the pending queue for the specified
+  ///             descriptor.
+  ///
+  /// @param[in]  desc  The pipeline descriptor that identifies the job
+  /// @param[in]  job   The compilation job closure to add
+  ///
+  /// @return     True if the job was successfully added to the queue, false
+  ///             if a job for this descriptor already exists.
+  ///
   bool AddJob(const PipelineDescriptor& desc, const fml::closure& job);
+
+  //----------------------------------------------------------------------------
+  /// @brief      Check if there are any pending compilation jobs in the queue.
+  ///
+  /// @return     True if there are pending jobs waiting to be processed,
+  ///             false otherwise.
+  ///
   bool HasPendingJobs();
 
  private:

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
@@ -43,7 +43,7 @@ class PipelineCompileQueue final
     : public std::enable_shared_from_this<PipelineCompileQueue> {
  public:
   static std::shared_ptr<PipelineCompileQueue> Create(
-      std::shared_ptr<fml::ConcurrentTaskRunner> worker_task_runner);
+      std::shared_ptr<fml::BasicTaskRunner> worker_task_runner);
 
   ~PipelineCompileQueue();
 
@@ -73,7 +73,7 @@ class PipelineCompileQueue final
   void PerformJobEagerly(const PipelineDescriptor& desc);
 
  private:
-  std::shared_ptr<fml::ConcurrentTaskRunner> worker_task_runner_;
+  std::shared_ptr<fml::BasicTaskRunner> worker_task_runner_;
   Mutex pending_jobs_mutex_;
   size_t priorities_elevated_ = {};
 
@@ -84,7 +84,7 @@ class PipelineCompileQueue final
       pending_jobs_ IPLR_GUARDED_BY(pending_jobs_mutex_);
 
   explicit PipelineCompileQueue(
-      std::shared_ptr<fml::ConcurrentTaskRunner> worker_task_runner);
+      std::shared_ptr<fml::BasicTaskRunner> worker_task_runner);
 
   fml::closure TakeJob(const PipelineDescriptor& desc);
 

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
@@ -48,6 +48,7 @@ class PipelineCompileQueue
   ~PipelineCompileQueue();
   explicit PipelineCompileQueue(
       std::shared_ptr<fml::BasicTaskRunner> worker_task_runner);
+  PipelineCompileQueue() = default;
 
   virtual ~PipelineCompileQueue();
 
@@ -84,10 +85,9 @@ class PipelineCompileQueue
   /// @return     If the job was successfully posted to the parallel task
   ///             runners.
   ///
-  virtual void PostJob(const fml::closure& job);
+  virtual void PostJob(const fml::closure& job) = 0;
 
  private:
-  std::shared_ptr<fml::BasicTaskRunner> worker_task_runner_;
   Mutex pending_jobs_mutex_;
   size_t priorities_elevated_ = {};
 

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
@@ -49,6 +49,7 @@ class PipelineCompileQueue
   explicit PipelineCompileQueue(
       std::shared_ptr<fml::BasicTaskRunner> worker_task_runner);
   PipelineCompileQueue() = default;
+  PipelineCompileQueue(bool wait_until_rendering);
 
   virtual ~PipelineCompileQueue();
 
@@ -86,6 +87,13 @@ class PipelineCompileQueue
   ///             runners.
   ///
   virtual void PostJob(const fml::closure& job) = 0;
+
+  bool WaitUntilRendering() { return wait_until_rendering_; };
+
+  void FlushPendingJobs();
+
+ protected:
+  bool wait_until_rendering_ = false;
 
  private:
   Mutex pending_jobs_mutex_;

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
@@ -93,7 +93,7 @@ class PipelineCompileQueue
   void FlushPendingJobs();
 
  protected:
-  bool wait_until_rendering_ = false;
+  std::atomic<bool> wait_until_rendering_ = false;
 
  private:
   Mutex pending_jobs_mutex_;

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
@@ -65,8 +65,8 @@ class PipelineCompileQueue
   /// @return     If the job was successfully posted to the parallel task
   /// runners.
   ///
-  virtual bool PostJobForDescriptor(const PipelineDescriptor& desc,
-                                    const fml::closure& job) = 0;
+  bool PostJobForDescriptor(const PipelineDescriptor& desc,
+                            const fml::closure& job);
 
   //----------------------------------------------------------------------------
   /// @brief      If the task has not yet been done, perform it eagerly on the
@@ -79,6 +79,18 @@ class PipelineCompileQueue
 
  protected:
   virtual void PostJob(const fml::closure& job) = 0;
+
+  //----------------------------------------------------------------------------
+  /// @brief      Called by PostJobForDescriptor after a job has been
+  ///             successfully added to the queue. Subclasses must implement
+  ///             this to define their scheduling strategy.
+  ///
+  ///             The default implementation for duplicate descriptors is to
+  ///             run the job eagerly. Subclasses can override this behavior
+  ///             by checking for duplicates before calling the base class.
+  ///
+  virtual void OnJobAdded() = 0;
+
   void DoOneJob();
   bool AddJob(const PipelineDescriptor& desc, const fml::closure& job);
   bool HasPendingJobs();

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
@@ -49,7 +49,6 @@ class PipelineCompileQueue
   explicit PipelineCompileQueue(
       std::shared_ptr<fml::BasicTaskRunner> worker_task_runner);
   PipelineCompileQueue() = default;
-  PipelineCompileQueue(bool wait_until_rendering);
 
   virtual ~PipelineCompileQueue();
 
@@ -66,8 +65,8 @@ class PipelineCompileQueue
   /// @return     If the job was successfully posted to the parallel task
   /// runners.
   ///
-  bool PostJobForDescriptor(const PipelineDescriptor& desc,
-                            const fml::closure& job);
+  virtual bool PostJobForDescriptor(const PipelineDescriptor& desc,
+                                    const fml::closure& job) = 0;
 
   //----------------------------------------------------------------------------
   /// @brief      If the task has not yet been done, perform it eagerly on the
@@ -88,34 +87,38 @@ class PipelineCompileQueue
   ///
   virtual void PostJob(const fml::closure& job) = 0;
 
-  bool WaitUntilRendering() { return wait_until_rendering_; };
-
-  void FlushPendingJobs();
+  void DoOneJob();
 
  protected:
-  std::atomic<bool> wait_until_rendering_ = false;
+  //----------------------------------------------------------------------------
+  /// @brief      Add a job to the pending jobs map.
+  ///
+  /// @param[in]  desc  The pipeline descriptor.
+  /// @param[in]  job   The job to add.
+  ///
+  /// @return     true if the job was successfully inserted, false if a job
+  ///             for the same descriptor already exists.
+  ///
+  bool AddJob(const PipelineDescriptor& desc, const fml::closure& job);
+
+  //----------------------------------------------------------------------------
+  /// @brief      Check if there are any pending jobs.
+  ///
+  /// @return     true if there are pending jobs, false otherwise.
+  ///
+  bool HasPendingJobs();
 
  private:
   Mutex pending_jobs_mutex_;
-  size_t priorities_elevated_ = {};
-
   std::unordered_map<PipelineDescriptor,
                      fml::closure,
                      ComparableHash<PipelineDescriptor>,
                      ComparableEqual<PipelineDescriptor>>
       pending_jobs_ IPLR_GUARDED_BY(pending_jobs_mutex_);
-
+  size_t priorities_elevated_ = {};
   fml::closure TakeJob(const PipelineDescriptor& desc);
-
   fml::closure TakeNextJob();
-
-  void DoOneJob();
-
   void FinishAllJobs();
-
-  void ProcessJobsSequentially();
-
-  bool HasPendingJobs();
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
@@ -42,12 +42,6 @@ namespace impeller {
 class PipelineCompileQueue
     : public std::enable_shared_from_this<PipelineCompileQueue> {
  public:
-  static std::shared_ptr<PipelineCompileQueue> Create(
-      std::shared_ptr<fml::BasicTaskRunner> worker_task_runner);
-
-  explicit PipelineCompileQueue(
-      std::shared_ptr<fml::BasicTaskRunner> worker_task_runner);
-
   PipelineCompileQueue() = default;
 
   virtual ~PipelineCompileQueue();

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
@@ -77,35 +77,10 @@ class PipelineCompileQueue
   ///
   void PerformJobEagerly(const PipelineDescriptor& desc);
 
-  //----------------------------------------------------------------------------
-  /// @brief      Post a job to the worker task runner.
-  ///
-  /// @param[in]  job   The job
-  ///
-  /// @return     If the job was successfully posted to the parallel task
-  ///             runners.
-  ///
-  virtual void PostJob(const fml::closure& job) = 0;
-
-  void DoOneJob();
-
  protected:
-  //----------------------------------------------------------------------------
-  /// @brief      Add a job to the pending jobs map.
-  ///
-  /// @param[in]  desc  The pipeline descriptor.
-  /// @param[in]  job   The job to add.
-  ///
-  /// @return     true if the job was successfully inserted, false if a job
-  ///             for the same descriptor already exists.
-  ///
+  virtual void PostJob(const fml::closure& job) = 0;
+  void DoOneJob();
   bool AddJob(const PipelineDescriptor& desc, const fml::closure& job);
-
-  //----------------------------------------------------------------------------
-  /// @brief      Check if there are any pending jobs.
-  ///
-  /// @return     true if there are pending jobs, false otherwise.
-  ///
   bool HasPendingJobs();
 
  private:

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
@@ -45,9 +45,9 @@ class PipelineCompileQueue
   static std::shared_ptr<PipelineCompileQueue> Create(
       std::shared_ptr<fml::BasicTaskRunner> worker_task_runner);
 
-  ~PipelineCompileQueue();
   explicit PipelineCompileQueue(
       std::shared_ptr<fml::BasicTaskRunner> worker_task_runner);
+
   PipelineCompileQueue() = default;
 
   virtual ~PipelineCompileQueue();

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
@@ -39,13 +39,17 @@ namespace impeller {
 ///             entirely optional. The queue skipping mechanism all assume the
 ///             optional availability of a compile queue.
 ///
-class PipelineCompileQueue final
+class PipelineCompileQueue
     : public std::enable_shared_from_this<PipelineCompileQueue> {
  public:
   static std::shared_ptr<PipelineCompileQueue> Create(
       std::shared_ptr<fml::BasicTaskRunner> worker_task_runner);
 
   ~PipelineCompileQueue();
+  explicit PipelineCompileQueue(
+      std::shared_ptr<fml::BasicTaskRunner> worker_task_runner);
+
+  virtual ~PipelineCompileQueue();
 
   PipelineCompileQueue(const PipelineCompileQueue&) = delete;
 
@@ -72,6 +76,16 @@ class PipelineCompileQueue final
   ///
   void PerformJobEagerly(const PipelineDescriptor& desc);
 
+  //----------------------------------------------------------------------------
+  /// @brief      Post a job to the worker task runner.
+  ///
+  /// @param[in]  job   The job
+  ///
+  /// @return     If the job was successfully posted to the parallel task
+  ///             runners.
+  ///
+  virtual void PostJob(const fml::closure& job);
+
  private:
   std::shared_ptr<fml::BasicTaskRunner> worker_task_runner_;
   Mutex pending_jobs_mutex_;
@@ -82,9 +96,6 @@ class PipelineCompileQueue final
                      ComparableHash<PipelineDescriptor>,
                      ComparableEqual<PipelineDescriptor>>
       pending_jobs_ IPLR_GUARDED_BY(pending_jobs_mutex_);
-
-  explicit PipelineCompileQueue(
-      std::shared_ptr<fml::BasicTaskRunner> worker_task_runner);
 
   fml::closure TakeJob(const PipelineDescriptor& desc);
 

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
@@ -112,6 +112,10 @@ class PipelineCompileQueue
   void DoOneJob();
 
   void FinishAllJobs();
+
+  void ProcessJobsSequentially();
+
+  bool HasPendingJobs();
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue_unittests.cc
@@ -1,0 +1,96 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/pipeline_compile_queue.h"
+
+#include <memory>
+
+#include "flutter/fml/closure.h"
+#include "flutter/testing/testing.h"
+
+namespace impeller {
+namespace testing {
+
+class TestPipelineCompileQueue : public PipelineCompileQueue {
+ public:
+  void PostJob(const fml::closure& job) override {
+    if (job) {
+      job();
+    }
+  }
+
+  void OnJobAdded() override {}
+
+  bool AddJobForTest(const PipelineDescriptor& desc, const fml::closure& job) {
+    return AddJob(desc, job);
+  }
+
+  bool HasPendingJobsForTest() { return HasPendingJobs(); }
+};
+
+TEST(PipelineCompileQueueTest, AddJobReturnsTrueForNewDescriptor) {
+  TestPipelineCompileQueue queue;
+  PipelineDescriptor desc;
+  bool job_executed = false;
+  fml::closure job = [&job_executed]() { job_executed = true; };
+
+  bool result = queue.AddJobForTest(desc, job);
+  EXPECT_TRUE(result);
+}
+
+TEST(PipelineCompileQueueTest, AddJobReturnsFalseForDuplicateDescriptor) {
+  TestPipelineCompileQueue queue;
+  PipelineDescriptor desc;
+  bool job1_executed = false;
+  bool job2_executed = false;
+  fml::closure job1 = [&job1_executed]() { job1_executed = true; };
+  fml::closure job2 = [&job2_executed]() { job2_executed = true; };
+
+  bool result1 = queue.AddJobForTest(desc, job1);
+  bool result2 = queue.AddJobForTest(desc, job2);
+
+  EXPECT_TRUE(result1);
+  EXPECT_FALSE(result2);
+}
+
+TEST(PipelineCompileQueueTest, HasPendingJobsReturnsCorrectState) {
+  TestPipelineCompileQueue queue;
+  PipelineDescriptor desc;
+  fml::closure job = []() {};
+
+  EXPECT_FALSE(queue.HasPendingJobsForTest());
+
+  queue.AddJobForTest(desc, job);
+  EXPECT_TRUE(queue.HasPendingJobsForTest());
+}
+
+TEST(PipelineCompileQueueTest, PerformJobEagerlyExecutesJob) {
+  TestPipelineCompileQueue queue;
+  PipelineDescriptor desc;
+  bool job_executed = false;
+  fml::closure job = [&job_executed]() { job_executed = true; };
+
+  queue.AddJobForTest(desc, job);
+  queue.PerformJobEagerly(desc);
+
+  EXPECT_TRUE(job_executed);
+  EXPECT_FALSE(queue.HasPendingJobsForTest());
+}
+
+TEST(PipelineCompileQueueTest, FinishAllJobsDrainsQueue) {
+  auto queue = std::make_shared<TestPipelineCompileQueue>();
+  PipelineDescriptor desc;
+  bool job_executed = false;
+  fml::closure job = [&job_executed]() { job_executed = true; };
+
+  queue->AddJobForTest(desc, job);
+  EXPECT_TRUE(queue->HasPendingJobsForTest());
+
+  queue.reset();
+
+  EXPECT_TRUE(job_executed);
+}
+
+}  // namespace testing
+}  // namespace impeller

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1032,7 +1032,6 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
     if (should_post_raster_task) {
       fml::TaskRunner::RunNowOrPostTask(raster_task_runner, raster_task);
     }
-
     latch.Signal();
   };
 

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1006,20 +1006,6 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
     }
   };
 
-  auto flush_task = [io_manager = io_manager_->GetWeakPtr()] {
-    if (io_manager) {
-      if (auto impeller_context = io_manager->GetImpellerContext()) {
-        if (auto pipeline_library = impeller_context->GetPipelineLibrary()) {
-          if (auto pipeline_compile_queue =
-                  pipeline_library->GetPipelineCompileQueue())
-            if (pipeline_compile_queue->WaitUntilRendering()) {
-              pipeline_compile_queue->FlushPendingJobs();
-            }
-        }
-      }
-    }
-  };
-
   // Threading: Capture platform view by raw pointer and not the weak pointer.
   // We are going to use the pointer on the IO thread which is not safe with a
   // weak pointer. However, we are preventing the platform view from being
@@ -1031,7 +1017,7 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
   auto io_task = [io_manager = io_manager_->GetWeakPtr(), platform_view,
                   ui_task_runner = task_runners_.GetUITaskRunner(), ui_task,
                   raster_task_runner = task_runners_.GetRasterTaskRunner(),
-                  raster_task, should_post_raster_task, &latch, flush_task] {
+                  raster_task, should_post_raster_task, &latch] {
     if (io_manager && !io_manager->GetResourceContext()) {
       sk_sp<GrDirectContext> resource_context =
           platform_view->CreateResourceContext();
@@ -1046,9 +1032,6 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
     if (should_post_raster_task) {
       fml::TaskRunner::RunNowOrPostTask(raster_task_runner, raster_task);
     }
-
-    // Step 3: Flush pending pipeline compilation jobs.
-    fml::TaskRunner::RunNowOrPostTask(raster_task_runner, flush_task);
 
     latch.Signal();
   };

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1006,6 +1006,20 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
     }
   };
 
+  auto flush_task = [io_manager = io_manager_->GetWeakPtr()] {
+    if (io_manager && io_manager->GetImpellerContext()) {
+      auto impeller_context = io_manager->GetImpellerContext();
+      if (impeller_context && impeller_context->GetPipelineLibrary()) {
+        auto pipeline_compile_queue =
+            impeller_context->GetPipelineLibrary()->GetPipelineCompileQueue();
+        if (pipeline_compile_queue &&
+            pipeline_compile_queue->WaitUntilRendering()) {
+          pipeline_compile_queue->FlushPendingJobs();
+        }
+      }
+    }
+  };
+
   // Threading: Capture platform view by raw pointer and not the weak pointer.
   // We are going to use the pointer on the IO thread which is not safe with a
   // weak pointer. However, we are preventing the platform view from being
@@ -1017,7 +1031,7 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
   auto io_task = [io_manager = io_manager_->GetWeakPtr(), platform_view,
                   ui_task_runner = task_runners_.GetUITaskRunner(), ui_task,
                   raster_task_runner = task_runners_.GetRasterTaskRunner(),
-                  raster_task, should_post_raster_task, &latch] {
+                  raster_task, should_post_raster_task, &latch, flush_task] {
     if (io_manager && !io_manager->GetResourceContext()) {
       sk_sp<GrDirectContext> resource_context =
           platform_view->CreateResourceContext();
@@ -1032,6 +1046,10 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
     if (should_post_raster_task) {
       fml::TaskRunner::RunNowOrPostTask(raster_task_runner, raster_task);
     }
+
+    // Step 3: Tell the IO thread that it could be start to link program.
+    fml::TaskRunner::RunNowOrPostTask(raster_task_runner, flush_task);
+
     latch.Signal();
   };
 

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1007,14 +1007,14 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
   };
 
   auto flush_task = [io_manager = io_manager_->GetWeakPtr()] {
-    if (io_manager && io_manager->GetImpellerContext()) {
-      auto impeller_context = io_manager->GetImpellerContext();
-      if (impeller_context && impeller_context->GetPipelineLibrary()) {
-        auto pipeline_compile_queue =
-            impeller_context->GetPipelineLibrary()->GetPipelineCompileQueue();
-        if (pipeline_compile_queue &&
-            pipeline_compile_queue->WaitUntilRendering()) {
-          pipeline_compile_queue->FlushPendingJobs();
+    if (io_manager) {
+      if (auto impeller_context = io_manager->GetImpellerContext()) {
+        if (auto pipeline_library = impeller_context->GetPipelineLibrary()) {
+          if (auto pipeline_compile_queue =
+                  pipeline_library->GetPipelineCompileQueue())
+            if (pipeline_compile_queue->WaitUntilRendering()) {
+              pipeline_compile_queue->FlushPendingJobs();
+            }
         }
       }
     }
@@ -1047,7 +1047,7 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
       fml::TaskRunner::RunNowOrPostTask(raster_task_runner, raster_task);
     }
 
-    // Step 3: Tell the IO thread that it could be start to link program.
+    // Step 3: Flush pending pipeline compilation jobs.
     fml::TaskRunner::RunNowOrPostTask(raster_task_runner, flush_task);
 
     latch.Signal();

--- a/engine/src/flutter/shell/common/shell_test_platform_view_gl.cc
+++ b/engine/src/flutter/shell/common/shell_test_platform_view_gl.cc
@@ -61,7 +61,8 @@ ShellTestPlatformViewGL::ShellTestPlatformViewGL(
       return;
     }
     impeller_context_ = impeller::ContextGLES::Create(
-        impeller::Flags{}, std::move(gl), ShaderLibraryMappings(), true);
+        impeller::Flags{}, std::move(gl), ShaderLibraryMappings(), true,
+        task_runners.GetIOTaskRunner());
   }
 }
 

--- a/engine/src/flutter/shell/platform/android/android_context_dynamic_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_context_dynamic_impeller.cc
@@ -139,9 +139,11 @@ GetActualRenderingAPIForImpeller(
 }  // namespace
 
 AndroidContextDynamicImpeller::AndroidContextDynamicImpeller(
-    const AndroidContext::ContextSettings& settings)
+    const AndroidContext::ContextSettings& settings,
+    fml::RefPtr<fml::TaskRunner> io_task_runner)
     : AndroidContext(AndroidRenderingAPI::kImpellerVulkan),
-      settings_(settings) {}
+      settings_(settings),
+      io_task_runner_(std::move(io_task_runner)) {}
 
 AndroidContextDynamicImpeller::~AndroidContextDynamicImpeller() = default;
 
@@ -185,7 +187,7 @@ void AndroidContextDynamicImpeller::SetupImpellerContext() {
   if (!vk_context_) {
     gl_context_ = std::make_shared<AndroidContextGLImpeller>(
         std::make_unique<impeller::egl::Display>(),
-        settings_.enable_gpu_tracing);
+        settings_.enable_gpu_tracing, io_task_runner_);
   }
 }
 

--- a/engine/src/flutter/shell/platform/android/android_context_dynamic_impeller.h
+++ b/engine/src/flutter/shell/platform/android/android_context_dynamic_impeller.h
@@ -23,7 +23,8 @@ namespace flutter {
 class AndroidContextDynamicImpeller : public AndroidContext {
  public:
   explicit AndroidContextDynamicImpeller(
-      const AndroidContext::ContextSettings& settings);
+      const AndroidContext::ContextSettings& settings,
+      fml::RefPtr<fml::TaskRunner> io_task_runner);
 
   ~AndroidContextDynamicImpeller();
 
@@ -51,6 +52,7 @@ class AndroidContextDynamicImpeller : public AndroidContext {
   const AndroidContext::ContextSettings settings_;
   std::shared_ptr<AndroidContextGLImpeller> gl_context_;
   std::shared_ptr<AndroidContextVKImpeller> vk_context_;
+  fml::RefPtr<fml::TaskRunner> io_task_runner_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AndroidContextDynamicImpeller);
 };

--- a/engine/src/flutter/shell/platform/android/android_context_gl_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_context_gl_impeller.cc
@@ -51,7 +51,8 @@ class AndroidContextGLImpeller::ReactorWorker final
 
 static std::shared_ptr<impeller::Context> CreateImpellerContext(
     const std::shared_ptr<impeller::ReactorGLES::Worker>& worker,
-    bool enable_gpu_tracing) {
+    bool enable_gpu_tracing,
+    fml::RefPtr<fml::TaskRunner> io_task_runner) {
   auto proc_table = std::make_unique<impeller::ProcTableGLES>(
       impeller::egl::CreateProcAddressResolver());
 
@@ -85,11 +86,11 @@ static std::shared_ptr<impeller::Context> CreateImpellerContext(
   auto context = impeller::ContextGLES::Create(
       impeller::Flags{}, std::move(proc_table),
       is_gles3 ? gles3_shader_mappings : gles2_shader_mappings,
-      enable_gpu_tracing);
+      enable_gpu_tracing, io_task_runner);
 #else
-  auto context =
-      impeller::ContextGLES::Create(impeller::Flags{}, std::move(proc_table),
-                                    gles2_shader_mappings, enable_gpu_tracing);
+  auto context = impeller::ContextGLES::Create(
+      impeller::Flags{}, std::move(proc_table), gles2_shader_mappings,
+      enable_gpu_tracing, io_task_runner);
 #endif  // !SLIMPELLER
 
   if (!context) {
@@ -107,10 +108,12 @@ static std::shared_ptr<impeller::Context> CreateImpellerContext(
 
 AndroidContextGLImpeller::AndroidContextGLImpeller(
     std::unique_ptr<impeller::egl::Display> display,
-    bool enable_gpu_tracing)
+    bool enable_gpu_tracing,
+    fml::RefPtr<fml::TaskRunner> io_task_runner)
     : AndroidContext(AndroidRenderingAPI::kImpellerOpenGLES),
       reactor_worker_(std::shared_ptr<ReactorWorker>(new ReactorWorker())),
-      display_(std::move(display)) {
+      display_(std::move(display)),
+      io_task_runner_(std::move(io_task_runner)) {
   if (!display_ || !display_->IsValid()) {
     FML_LOG(ERROR) << "Could not create context with invalid EGL display.";
     return;
@@ -174,8 +177,8 @@ AndroidContextGLImpeller::AndroidContextGLImpeller(
     return;
   }
 
-  auto impeller_context =
-      CreateImpellerContext(reactor_worker_, enable_gpu_tracing);
+  auto impeller_context = CreateImpellerContext(
+      reactor_worker_, enable_gpu_tracing, io_task_runner_);
 
   if (!impeller_context) {
     FML_LOG(ERROR) << "Could not create Impeller context.";

--- a/engine/src/flutter/shell/platform/android/android_context_gl_impeller.h
+++ b/engine/src/flutter/shell/platform/android/android_context_gl_impeller.h
@@ -6,6 +6,7 @@
 #define FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_CONTEXT_GL_IMPELLER_H_
 
 #include "flutter/fml/macros.h"
+#include "flutter/fml/task_runner.h"
 #include "flutter/impeller/toolkit/egl/display.h"
 #include "flutter/shell/platform/android/context/android_context.h"
 
@@ -14,7 +15,8 @@ namespace flutter {
 class AndroidContextGLImpeller : public AndroidContext {
  public:
   AndroidContextGLImpeller(std::unique_ptr<impeller::egl::Display> display,
-                           bool enable_gpu_tracing);
+                           bool enable_gpu_tracing,
+                           fml::RefPtr<fml::TaskRunner> io_task_runner);
 
   ~AndroidContextGLImpeller();
 
@@ -42,6 +44,7 @@ class AndroidContextGLImpeller : public AndroidContext {
   std::unique_ptr<impeller::egl::Context> onscreen_context_;
   std::unique_ptr<impeller::egl::Context> offscreen_context_;
   bool is_valid_ = false;
+  fml::RefPtr<fml::TaskRunner> io_task_runner_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AndroidContextGLImpeller);
 };

--- a/engine/src/flutter/shell/platform/android/platform_view_android.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android.cc
@@ -108,7 +108,8 @@ static std::shared_ptr<flutter::AndroidContext> CreateAndroidContext(
     const flutter::TaskRunners& task_runners,
     AndroidRenderingAPI android_rendering_api,
     bool enable_opengl_gpu_tracing,
-    const AndroidContext::ContextSettings& settings) {
+    const AndroidContext::ContextSettings& settings,
+    fml::RefPtr<fml::TaskRunner> io_task_runner) {
   switch (android_rendering_api) {
 #if !SLIMPELLER
     case AndroidRenderingAPI::kSoftware:
@@ -123,11 +124,12 @@ static std::shared_ptr<flutter::AndroidContext> CreateAndroidContext(
       return std::make_unique<AndroidContextVKImpeller>(settings);
     case AndroidRenderingAPI::kImpellerOpenGLES:
       return std::make_unique<AndroidContextGLImpeller>(
-          std::make_unique<impeller::egl::Display>(),
-          enable_opengl_gpu_tracing);
+          std::make_unique<impeller::egl::Display>(), enable_opengl_gpu_tracing,
+          io_task_runner);
     case AndroidRenderingAPI::kImpellerAutoselect:
       // Determine if we're using GL or Vulkan.
-      return std::make_unique<AndroidContextDynamicImpeller>(settings);
+      return std::make_unique<AndroidContextDynamicImpeller>(settings,
+                                                             io_task_runner);
   }
   FML_UNREACHABLE();
 }
@@ -145,7 +147,8 @@ PlatformViewAndroid::PlatformViewAndroid(
               task_runners,
               rendering_api,
               delegate.OnPlatformViewGetSettings().enable_opengl_gpu_tracing,
-              CreateContextSettings(delegate.OnPlatformViewGetSettings()))) {}
+              CreateContextSettings(delegate.OnPlatformViewGetSettings()),
+              task_runners.GetIOTaskRunner())) {}
 
 PlatformViewAndroid::PlatformViewAndroid(
     PlatformView::Delegate& delegate,

--- a/engine/src/flutter/shell/platform/android/platform_view_android.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android.cc
@@ -109,7 +109,7 @@ static std::shared_ptr<flutter::AndroidContext> CreateAndroidContext(
     AndroidRenderingAPI android_rendering_api,
     bool enable_opengl_gpu_tracing,
     const AndroidContext::ContextSettings& settings,
-    fml::RefPtr<fml::TaskRunner> io_task_runner) {
+    const fml::RefPtr<fml::TaskRunner>& io_task_runner) {
   switch (android_rendering_api) {
 #if !SLIMPELLER
     case AndroidRenderingAPI::kSoftware:

--- a/engine/src/flutter/shell/platform/embedder/embedder.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder.cc
@@ -492,7 +492,8 @@ InferOpenGLPlatformViewCreationCallback(
               shell.GetTaskRunners(),  // task runners
               std::make_unique<flutter::EmbedderSurfaceGLImpeller>(
                   gl_dispatch_table, fbo_reset_after_present,
-                  view_embedder),       // embedder_surface
+                  view_embedder,  // embedder_surface
+                  shell.GetTaskRunners().GetIOTaskRunner()),
               platform_dispatch_table,  // embedder platform dispatch table
               view_embedder             // external view embedder
           );

--- a/engine/src/flutter/shell/platform/embedder/embedder.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder.cc
@@ -493,7 +493,7 @@ InferOpenGLPlatformViewCreationCallback(
               std::make_unique<flutter::EmbedderSurfaceGLImpeller>(
                   gl_dispatch_table, fbo_reset_after_present,
                   view_embedder,  // embedder_surface
-                  shell.GetTaskRunners().GetIOTaskRunner()),
+                  shell.GetTaskRunners().GetIOTaskRunner()),  // io_task_runner
               platform_dispatch_table,  // embedder platform dispatch table
               view_embedder             // external view embedder
           );

--- a/engine/src/flutter/shell/platform/embedder/embedder_surface_gl_impeller.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_surface_gl_impeller.cc
@@ -64,7 +64,8 @@ class ReactorWorker final : public impeller::ReactorGLES::Worker {
 EmbedderSurfaceGLImpeller::EmbedderSurfaceGLImpeller(
     EmbedderSurfaceGLSkia::GLDispatchTable gl_dispatch_table,
     bool fbo_reset_after_present,
-    std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder)
+    std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder,
+    fml::RefPtr<fml::TaskRunner> io_task_runner)
     : gl_dispatch_table_(std::move(gl_dispatch_table)),
       fbo_reset_after_present_(fbo_reset_after_present),
       external_view_embedder_(std::move(external_view_embedder)),
@@ -92,7 +93,7 @@ EmbedderSurfaceGLImpeller::EmbedderSurfaceGLImpeller(
 
   impeller_context_ = impeller::ContextGLES::Create(
       impeller::Flags{}, std::move(gl), shader_mappings,
-      /*enable_gpu_tracing=*/false);
+      /*enable_gpu_tracing=*/false, std::move(io_task_runner));
 
   if (!impeller_context_) {
     FML_LOG(ERROR) << "Could not create Impeller context.";

--- a/engine/src/flutter/shell/platform/embedder/embedder_surface_gl_impeller.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_surface_gl_impeller.h
@@ -30,7 +30,8 @@ class EmbedderSurfaceGLImpeller final : public EmbedderSurface,
   EmbedderSurfaceGLImpeller(
       EmbedderSurfaceGLSkia::GLDispatchTable gl_dispatch_table,
       bool fbo_reset_after_present,
-      std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder);
+      std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder,
+      fml::RefPtr<fml::TaskRunner> io_task_runner);
 
   ~EmbedderSurfaceGLImpeller() override;
 

--- a/engine/src/flutter/skwasm/render_context_impeller.cc
+++ b/engine/src/flutter/skwasm/render_context_impeller.cc
@@ -128,7 +128,7 @@ std::unique_ptr<Skwasm::RenderContext> Skwasm::RenderContext::Make(
 
   auto context = impeller::ContextGLES::Create(
       impeller::Flags{}, std::move(gl), ShaderLibraryMappingsForApplication(),
-      false);
+      false, nullptr);
 
   auto worker = std::make_shared<ReactorWorker>();
   context->AddReactorWorker(worker);

--- a/engine/src/flutter/skwasm/render_context_impeller.cc
+++ b/engine/src/flutter/skwasm/render_context_impeller.cc
@@ -128,7 +128,7 @@ std::unique_ptr<Skwasm::RenderContext> Skwasm::RenderContext::Make(
 
   auto context = impeller::ContextGLES::Create(
       impeller::Flags{}, std::move(gl), ShaderLibraryMappingsForApplication(),
-      false, nullptr);
+      false);
 
   auto worker = std::make_shared<ReactorWorker>();
   context->AddReactorWorker(worker);


### PR DESCRIPTION
Fix https://github.com/flutter-tizen/embedder/issues/157
Impeller eagerly sets up the entire set of pipeline state objects (PSOs) it may need during renderer setup. This works fine on mid to high-end devices as the setup completes well before the first frame is rendered.

However on low-end devices, not all PSOs may be ready before the first frame is rendered. Low-end device usually don't have as much available concurrency and are slower to boot. On these devices, the rendering thread had to wait for the background compile job to be completed. It was also observed that the relatively higher priority render thread was waiting on a background thread to finish a PSO compile job. The PSO compile job could also be stuck behind another job that was not immediately needed. This made the situation on low end devices less than ideal.

https://github.com/flutter/flutter/pull/180022, this PR fix PSO stuck issue for Vulkan on low end devices.
Current PR can fix the PSO stuck issue for GLES on low end devices. Related issue : https://github.com/flutter/flutter/issues/176657

This PR can improve app startup time for impeller+GLES on low-end devices.
https://github.com/flutter/flutter/pull/180022 has provided solution for impeller + vulkan.

Impeller+GLES has a special case: resource loading cannot be arbitrarily placed on other threads; it needs to be done on the I/O thread because this thread shares the context with the GPU thread. Therefore, this PR introduces the I/O task runner into PipelineCompileQueueGLES. However, since the I/O task runner may handle other tasks, we cannot put all jobs into the I/O thread at once. My current solution is to wait for the previous job to finish before putting the next one into the I/O thread.

Main changes:

Introduce fml::RefPtrfml::TaskRunner into PipelineCompileQueueGLES.
Extract new class PipelineCompileQueueVulkan for vulkan, because the runners are on different threads.